### PR TITLE
Fixes aliasing in firefox

### DIFF
--- a/src/lib/components/card.svelte
+++ b/src/lib/components/card.svelte
@@ -409,6 +409,7 @@
 		border-radius: var(--radius);
 		image-rendering: optimizeQuality;
 		transform-style: preserve-3d;
+		outline: 1px solid transparent;
 	}
 
 	.card__back {


### PR DESCRIPTION
First of all, really cool project :) This PR uses a transparent outline to force firefox to apply anti aliasing.

![image](https://user-images.githubusercontent.com/83799/196490244-351a21ce-1008-490e-b187-d387fe4440cb.png)
