### PR TITLE
Update cards to be buttons to allow for keyboard navigation

### DIFF
--- a/src/lib/components/card.svelte
+++ b/src/lib/components/card.svelte
@@ -17,6 +17,7 @@
 	export let rarity = "common";
 	export let gallery = false;
 	export let showcase = false;
+	export let name;
 
 	const base = "https://images.pokemontcg.io/"
 
@@ -314,14 +315,15 @@
 	bind:this={thisCard}>
 
 	<div class="card__translater">
-		<div
+		<button
 			class="card__rotator"
 			bind:this={rotator}
-			on:pointerup={activate}
 			on:pointermove={interact}
 			on:mouseout={interactEnd}
 			on:blur={deactivate}
+			on:click={activate}
 			tabindex=0
+			aria-label="Expand card for {name}"
 		>
 			<img class="card__back" src="{cardBack}" alt="" />
 			<div class="card__front">
@@ -329,7 +331,7 @@
 				<Shine {subtypes} {supertype} />
 				<Glare {subtypes} />
 			</div>
-		</div>
+		</button>
 	</div>
 </div>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -71,6 +71,7 @@
 					subtypes={cards[23].subtypes}
 					rarity={cards[23].rarity}
 					showcase={true}
+					name={cards[23].name}
 				/>
 			{/await}
 		</div>
@@ -106,6 +107,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -130,6 +132,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -154,6 +157,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -178,6 +182,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -202,6 +207,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -229,6 +235,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -257,6 +264,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -281,6 +289,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -305,6 +314,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -333,6 +343,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -357,6 +368,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -381,6 +393,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -404,6 +417,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -427,6 +441,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}
@@ -449,6 +464,7 @@
 					supertype={card.supertype}
 					subtypes={card.subtypes}
 					rarity={card.rarity}
+					name={card.name}
 				/>
 			{/each}
 		{/await}

--- a/static/cards.css
+++ b/static/cards.css
@@ -1,22 +1,21 @@
+
 .card__shine {
-	--grain: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCI+CjxmaWx0ZXIgaWQ9Im4iPgo8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iLjciIG51bU9jdGF2ZXM9IjEwIiBzdGl0Y2hUaWxlcz0ic3RpdGNoIj48L2ZlVHVyYnVsZW5jZT4KPC9maWx0ZXI+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjMDAwIj48L3JlY3Q+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWx0ZXI9InVybCgjbikiIG9wYWNpdHk9IjAuMyI+PC9yZWN0Pgo8L3N2Zz4=');
 
-	--space: 5%;
-	--angle: 133deg;
-	--imgsize: 500px;
+  --grain: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCI+CjxmaWx0ZXIgaWQ9Im4iPgo8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iLjciIG51bU9jdGF2ZXM9IjEwIiBzdGl0Y2hUaWxlcz0ic3RpdGNoIj48L2ZlVHVyYnVsZW5jZT4KPC9maWx0ZXI+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjMDAwIj48L3JlY3Q+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWx0ZXI9InVybCgjbikiIG9wYWNpdHk9IjAuMyI+PC9yZWN0Pgo8L3N2Zz4=");
+  
+  --space: 5%;
+  --angle: 133deg;
+  --imgsize: 500px;
 
-	--red: #f80e7b;
-	--yel: #eedf10;
-	--gre: #21e985;
-	--blu: #0dbde9;
-	--vio: #c929f1;
+  --red: #f80e7b;
+  --yel: #eedf10;
+  --gre: #21e985;
+  --blu: #0dbde9;
+  --vio: #c929f1;
+
 }
 
-button[class^='card'] {
-	border: none;
-	background: transparent;
-	padding: 0;
-}
+
 
 /*
 
@@ -24,125 +23,83 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo'] .card__shine {
-	--space: 2px;
-	--h: 21;
-	--s: 70%;
-	--l: 50%;
-	--bars: 24px;
-	--bar-color: rgba(255, 255, 255, 0.6);
-	--bar-bg: rgb(10, 10, 10);
+.card[data-rarity="rare holo"] .card__shine {
 
-	clip-path: inset(10% 8.5% 52.5% 8.5%);
+  --space: 2px;
+  --h: 21;
+  --s: 70%;
+  --l: 50%;
+  --bars: 24px;
+  --bar-color: rgba(255, 255, 255, 0.6);
+  --bar-bg: rgb(10, 10, 10);
 
-	background-image: repeating-linear-gradient(
-			90deg,
-			hsl(calc(var(--h) * 0), var(--s), var(--l)) calc(var(--space) * 0),
-			hsl(calc(var(--h) * 0), var(--s), var(--l)) calc(var(--space) * 1),
-			black calc(var(--space) * 1.001),
-			black calc(var(--space) * 1.999),
-			hsl(calc(var(--h) * 1), var(--s), var(--l)) calc(var(--space) * 2),
-			hsl(calc(var(--h) * 1), var(--s), var(--l)) calc(var(--space) * 3),
-			black calc(var(--space) * 3.001),
-			black calc(var(--space) * 3.999),
-			hsl(calc(var(--h) * 2), var(--s), var(--l)) calc(var(--space) * 4),
-			hsl(calc(var(--h) * 2), var(--s), var(--l)) calc(var(--space) * 5),
-			black calc(var(--space) * 5.001),
-			black calc(var(--space) * 5.999),
-			hsl(calc(var(--h) * 3), var(--s), var(--l)) calc(var(--space) * 6),
-			hsl(calc(var(--h) * 3), var(--s), var(--l)) calc(var(--space) * 7),
-			black calc(var(--space) * 7.001),
-			black calc(var(--space) * 7.999),
-			hsl(calc(var(--h) * 4), var(--s), var(--l)) calc(var(--space) * 8),
-			hsl(calc(var(--h) * 4), var(--s), var(--l)) calc(var(--space) * 9),
-			black calc(var(--space) * 9.001),
-			black calc(var(--space) * 9.999),
-			hsl(calc(var(--h) * 5), var(--s), var(--l)) calc(var(--space) * 10),
-			hsl(calc(var(--h) * 5), var(--s), var(--l)) calc(var(--space) * 11),
-			black calc(var(--space) * 11.001),
-			black calc(var(--space) * 11.999),
-			hsl(calc(var(--h) * 6), var(--s), var(--l)) calc(var(--space) * 12),
-			hsl(calc(var(--h) * 6), var(--s), var(--l)) calc(var(--space) * 13),
-			black calc(var(--space) * 13.001),
-			black calc(var(--space) * 13.999),
-			hsl(calc(var(--h) * 7), var(--s), var(--l)) calc(var(--space) * 14),
-			hsl(calc(var(--h) * 7), var(--s), var(--l)) calc(var(--space) * 15),
-			black calc(var(--space) * 15.001),
-			black calc(var(--space) * 15.999),
-			hsl(calc(var(--h) * 8), var(--s), var(--l)) calc(var(--space) * 16),
-			hsl(calc(var(--h) * 8), var(--s), var(--l)) calc(var(--space) * 17),
-			black calc(var(--space) * 17.001),
-			black calc(var(--space) * 17.999),
-			hsl(calc(var(--h) * 9), var(--s), var(--l)) calc(var(--space) * 18),
-			hsl(calc(var(--h) * 9), var(--s), var(--l)) calc(var(--space) * 19),
-			black calc(var(--space) * 19.001),
-			black calc(var(--space) * 19.999),
-			hsl(calc(var(--h) * 10), var(--s), var(--l)) calc(var(--space) * 20),
-			hsl(calc(var(--h) * 10), var(--s), var(--l)) calc(var(--space) * 21),
-			black calc(var(--space) * 21.001),
-			black calc(var(--space) * 21.999),
-			hsl(calc(var(--h) * 11), var(--s), var(--l)) calc(var(--space) * 22),
-			hsl(calc(var(--h) * 11), var(--s), var(--l)) calc(var(--space) * 23),
-			black calc(var(--space) * 23.001),
-			black calc(var(--space) * 23.999),
-			hsl(calc(var(--h) * 12), var(--s), var(--l)) calc(var(--space) * 24),
-			hsl(calc(var(--h) * 12), var(--s), var(--l)) calc(var(--space) * 25),
-			black calc(var(--space) * 25.001),
-			black calc(var(--space) * 25.999),
-			hsl(calc(var(--h) * 13), var(--s), var(--l)) calc(var(--space) * 26),
-			hsl(calc(var(--h) * 13), var(--s), var(--l)) calc(var(--space) * 27),
-			black calc(var(--space) * 27.001),
-			black calc(var(--space) * 27.999),
-			hsl(calc(var(--h) * 14), var(--s), var(--l)) calc(var(--space) * 28),
-			hsl(calc(var(--h) * 14), var(--s), var(--l)) calc(var(--space) * 29),
-			black calc(var(--space) * 29.001),
-			black calc(var(--space) * 29.999),
-			hsl(calc(var(--h) * 15), var(--s), var(--l)) calc(var(--space) * 30),
-			hsl(calc(var(--h) * 15), var(--s), var(--l)) calc(var(--space) * 31),
-			black calc(var(--space) * 31.001),
-			black calc(var(--space) * 31.999)
-		),
-		repeating-linear-gradient(
-			90deg,
-			var(--vio),
-			var(--blu),
-			var(--gre),
-			var(--yel),
-			var(--red),
-			var(--vio)
-		),
-		repeating-linear-gradient(
-			90deg,
-			var(--bar-bg) calc(var(--bars) * 2),
-			var(--bar-color) calc(var(--bars) * 3),
-			var(--bar-bg) calc(var(--bars) * 3.5),
-			var(--bar-color) calc(var(--bars) * 4),
-			var(--bar-bg) calc(var(--bars) * 5),
-			var(--bar-bg) calc(var(--bars) * 12)
-		),
-		repeating-linear-gradient(
-			90deg,
-			var(--bar-bg) calc(var(--bars) * 2),
-			var(--bar-color) calc(var(--bars) * 3),
-			var(--bar-bg) calc(var(--bars) * 3.5),
-			var(--bar-color) calc(var(--bars) * 4),
-			var(--bar-bg) calc(var(--bars) * 5),
-			var(--bar-bg) calc(var(--bars) * 9)
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(230, 230, 230, 0.85) 0%,
-			rgba(200, 200, 200, 0.1) 25%,
-			rgb(0, 0, 0) 90%
-		);
+  clip-path: inset( 10% 8.5% 52.5% 8.5% );
 
-	background-blend-mode: soft-light, soft-light, screen, overlay;
-	background-position: center, calc(((50% - var(--posx)) * 25) + 50%) center,
-		calc(var(--posx) * -1.2) var(--posy), var(--pos), center;
-	background-size: 100% 100%, 200% 200%, 237% 237%, 195% 195%, 120% 120%;
+  background-image:
+    repeating-linear-gradient( 90deg, 
+      hsl(calc(var(--h)*0), var(--s), var(--l)) calc(var(--space)*0), hsl(calc(var(--h)*0), var(--s), var(--l)) calc(var(--space)*1), 
+      black calc(var(--space)*1.001), black calc(var(--space)*1.999),
+      hsl(calc(var(--h)*1), var(--s), var(--l)) calc(var(--space)*2), hsl(calc(var(--h)*1), var(--s), var(--l)) calc(var(--space)*3), 
+      black calc(var(--space)*3.001), black calc(var(--space)*3.999),
+      hsl(calc(var(--h)*2), var(--s), var(--l)) calc(var(--space)*4), hsl(calc(var(--h)*2), var(--s), var(--l)) calc(var(--space)*5), 
+      black calc(var(--space)*5.001), black calc(var(--space)*5.999),
+      hsl(calc(var(--h)*3), var(--s), var(--l)) calc(var(--space)*6), hsl(calc(var(--h)*3), var(--s), var(--l)) calc(var(--space)*7), 
+      black calc(var(--space)*7.001), black calc(var(--space)*7.999),
+      hsl(calc(var(--h)*4), var(--s), var(--l)) calc(var(--space)*8), hsl(calc(var(--h)*4), var(--s), var(--l)) calc(var(--space)*9), 
+      black calc(var(--space)*9.001), black calc(var(--space)*9.999),
+      hsl(calc(var(--h)*5), var(--s), var(--l)) calc(var(--space)*10), hsl(calc(var(--h)*5), var(--s), var(--l)) calc(var(--space)*11), 
+      black calc(var(--space)*11.001), black calc(var(--space)*11.999),
+      hsl(calc(var(--h)*6), var(--s), var(--l)) calc(var(--space)*12), hsl(calc(var(--h)*6), var(--s), var(--l)) calc(var(--space)*13), 
+      black calc(var(--space)*13.001), black calc(var(--space)*13.999),
+      hsl(calc(var(--h)*7), var(--s), var(--l)) calc(var(--space)*14), hsl(calc(var(--h)*7), var(--s), var(--l)) calc(var(--space)*15), 
+      black calc(var(--space)*15.001), black calc(var(--space)*15.999),
+      hsl(calc(var(--h)*8), var(--s), var(--l)) calc(var(--space)*16), hsl(calc(var(--h)*8), var(--s), var(--l)) calc(var(--space)*17), 
+      black calc(var(--space)*17.001), black calc(var(--space)*17.999),
+      hsl(calc(var(--h)*9), var(--s), var(--l)) calc(var(--space)*18), hsl(calc(var(--h)*9), var(--s), var(--l)) calc(var(--space)*19), 
+      black calc(var(--space)*19.001), black calc(var(--space)*19.999),
+      hsl(calc(var(--h)*10), var(--s), var(--l)) calc(var(--space)*20), hsl(calc(var(--h)*10), var(--s), var(--l)) calc(var(--space)*21), 
+      black calc(var(--space)*21.001), black calc(var(--space)*21.999),
+      hsl(calc(var(--h)*11), var(--s), var(--l)) calc(var(--space)*22), hsl(calc(var(--h)*11), var(--s), var(--l)) calc(var(--space)*23), 
+      black calc(var(--space)*23.001), black calc(var(--space)*23.999),
+      hsl(calc(var(--h)*12), var(--s), var(--l)) calc(var(--space)*24), hsl(calc(var(--h)*12), var(--s), var(--l)) calc(var(--space)*25), 
+      black calc(var(--space)*25.001), black calc(var(--space)*25.999),
+      hsl(calc(var(--h)*13), var(--s), var(--l)) calc(var(--space)*26), hsl(calc(var(--h)*13), var(--s), var(--l)) calc(var(--space)*27), 
+      black calc(var(--space)*27.001), black calc(var(--space)*27.999),
+      hsl(calc(var(--h)*14), var(--s), var(--l)) calc(var(--space)*28), hsl(calc(var(--h)*14), var(--s), var(--l)) calc(var(--space)*29), 
+      black calc(var(--space)*29.001), black calc(var(--space)*29.999),
+      hsl(calc(var(--h)*15), var(--s), var(--l)) calc(var(--space)*30), hsl(calc(var(--h)*15), var(--s), var(--l)) calc(var(--space)*31), 
+      black calc(var(--space)*31.001), black calc(var(--space)*31.999)
+    ),
+    repeating-linear-gradient( 90deg, 
+      var(--vio), var(--blu), var(--gre), var(--yel), var(--red), var(--vio)
+    ),
+    repeating-linear-gradient( 90deg, 
+      var(--bar-bg) calc(var(--bars)*2), var(--bar-color) calc(var(--bars)*3), var(--bar-bg) calc(var(--bars)*3.5), var(--bar-color) calc(var(--bars)*4), var(--bar-bg) calc(var(--bars)*5), var(--bar-bg) calc(var(--bars)*12)
+    ),
+    repeating-linear-gradient( 90deg, 
+      var(--bar-bg) calc(var(--bars)*2), var(--bar-color) calc(var(--bars)*3), var(--bar-bg) calc(var(--bars)*3.5), var(--bar-color) calc(var(--bars)*4), var(--bar-bg) calc(var(--bars)*5), var(--bar-bg) calc(var(--bars)*9)
+    ),
+    radial-gradient(
+      farthest-corner circle 
+        at var(--mx) var(--my), 
+        rgba(230, 230, 230, 0.85) 0%, 
+        rgba(200, 200, 200, .1) 25%, 
+        rgb(0, 0, 0) 90%
+      );
 
-	filter: brightness(calc((var(--hyp) + 0.7) * 0.7)) contrast(3) saturate(0.35);
+  background-blend-mode: soft-light, soft-light, screen, overlay;
+  background-position: center, calc(((50% - var(--posx)) * 25) + 50%) center, calc(var(--posx)*-1.2) var(--posy), var(--pos), center;
+  background-size: 100% 100%, 200% 200%, 237% 237%, 195% 195%, 120% 120%;
+
+  filter: brightness(calc((var(--hyp) + 0.7)*0.7)) contrast(3) saturate(.35);
+
 }
+
+
+
+
+
+
 
 /*
 
@@ -150,89 +107,96 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo galaxy'] .card__glare {
-	background-image: radial-gradient(
-		farthest-corner circle at var(--mx) var(--my),
-		rgba(222, 245, 250, 0.7) 10%,
-		rgba(255, 255, 255, 0.5) 20%,
-		rgba(0, 0, 0, 0.5) 90%
-	);
+.card[data-rarity="rare holo galaxy"] .card__glare {
+  
+  background-image:
+  radial-gradient( 
+    farthest-corner circle 
+    at var(--mx) var(--my), 
+    rgba(222, 245, 250, 0.7) 10%, 
+    rgba(255, 255, 255, 0.5) 20%, 
+    rgba(0, 0, 0, 0.5) 90% 
+    );
+    
 }
 
-.card[data-rarity='rare holo'] .card__glare:after,
-.card[data-rarity='rare holo galaxy'] .card__glare:after {
-	content: '';
-	clip-path: inset(10% 8.5% 52.5% 8.5%);
-	background-image: radial-gradient(
-		farthest-corner circle at var(--mx) var(--my),
-		rgb(229, 239, 255) 5%,
-		rgba(100, 100, 100, 0.5) 35%,
-		rgba(0, 0, 0, 0.9) 80%
-	);
+.card[data-rarity="rare holo"] .card__glare:after,
+.card[data-rarity="rare holo galaxy"] .card__glare:after {
+
+  content: "";
+  clip-path: inset( 10% 8.5% 52.5% 8.5% );
+  background-image: 
+    radial-gradient( 
+      farthest-corner circle 
+      at var(--mx) var(--my), 
+      rgb(229, 239, 255) 5%, 
+      rgba(100, 100, 100, 0.5) 35%, 
+      rgba(0, 0, 0, 0.9) 80% 
+    );
+
 }
 
-.card[data-rarity='rare holo galaxy'] .card__shine {
-	--space: 80px;
-	--h: 21;
-	--s: 70%;
-	--l: 50%;
-	--bars: 50px;
-	--bar-color: rgba(255, 255, 255, 0.6);
-	--bar-bg: rgb(10, 10, 10);
+.card[data-rarity="rare holo galaxy"] .card__shine {
 
-	clip-path: inset(10% 8.5% 52.5% 8.5%);
+  --space: 80px;
+  --h: 21;
+  --s: 70%;
+  --l: 50%;
+  --bars: 50px;
+  --bar-color: rgba(255, 255, 255, 0.6);
+  --bar-bg: rgb(10, 10, 10);
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
-		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
-		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
-		repeating-linear-gradient(
-			82deg,
-			rgb(218, 56, 50) calc(var(--space) * 1),
-			rgb(219, 204, 86) calc(var(--space) * 2),
-			rgb(121, 199, 58) calc(var(--space) * 3),
-			rgb(58, 192, 183) calc(var(--space) * 4),
-			rgb(71, 98, 207) calc(var(--space) * 5),
-			rgb(170, 69, 209) calc(var(--space) * 6),
-			rgb(218, 56, 50) calc(var(--space) * 10)
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(255, 255, 255, 0.6) 5%,
-			rgba(150, 150, 150, 0.3) 40%,
-			rgb(0, 0, 0) 100%
-		);
+  clip-path: inset( 10% 8.5% 52.5% 8.5% );
 
-	background-blend-mode: color-dodge, color-burn, saturation, screen;
-	background-position: center, center, center,
-		calc(((50% - var(--posx)) * 2.5) + 50%) calc(((50% - var(--posy)) * 2.5) + 50%), center;
-	background-size: cover, cover, cover, 600% 1200%, cover;
+  background-image: 
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"),
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"),
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"), 
+    repeating-linear-gradient(
+      82deg, 
+      rgb(218, 56, 50) calc(var(--space)*1), 
+      rgb(219, 204, 86) calc(var(--space)*2), 
+      rgb(121, 199, 58) calc(var(--space)*3), 
+      rgb(58, 192, 183) calc(var(--space)*4), 
+      rgb(71, 98, 207) calc(var(--space)*5), 
+      rgb(170, 69, 209) calc(var(--space)*6), 
+      rgb(218, 56, 50) calc(var(--space)*10) 
+    ), 
+    radial-gradient( 
+      farthest-corner circle 
+      at var(--mx) var(--my), 
+      rgba(255, 255, 255, 0.6) 5%, 
+      rgba(150, 150, 150, .3) 40%, 
+      rgb(0, 0, 0) 100% 
+  );
 
-	filter: brightness(0.75) contrast(1.2) saturate(1.5);
-	mix-blend-mode: color-dodge;
+  background-blend-mode: color-dodge, color-burn, saturation, screen;
+  background-position: center, center, center, calc(((50% - var(--posx)) * 2.5) + 50%) calc(((50% - var(--posy)) * 2.5) + 50%), center;
+  background-size: cover, cover, cover, 600% 1200%, cover;
+
+  filter: brightness(.75) contrast(1.2) saturate(1.5);
+  mix-blend-mode: color-dodge;
+
 }
 
-.card[data-rarity='rare holo'][data-subtypes^='stage'] .card__shine,
-.card[data-rarity='rare holo galaxy'][data-subtypes^='stage'] .card__shine,
-.card[data-rarity='rare holo'][data-subtypes^='stage'] .card__glare:after,
-.card[data-rarity='rare holo galaxy'][data-subtypes^='stage'] .card__glare:after {
-	clip-path: polygon(
-		91.78% 10%,
-		57% 10%,
-		53.92% 12%,
-		17% 12%,
-		16% 14%,
-		12% 16%,
-		8.5% 16%,
-		7.93% 47.41%,
-		92.07% 47.41%
-	);
+
+
+.card[data-rarity="rare holo"][data-subtypes^="stage"] .card__shine,
+.card[data-rarity="rare holo galaxy"][data-subtypes^="stage"] .card__shine,
+.card[data-rarity="rare holo"][data-subtypes^="stage"] .card__glare:after,
+.card[data-rarity="rare holo galaxy"][data-subtypes^="stage"] .card__glare:after {
+  clip-path: polygon(91.78% 10%, 57% 10%, 53.92% 12.00%, 17% 12%, 16% 14%, 12% 16%, 8.5% 16%, 7.93% 47.41%, 92.07% 47.41%);
 }
-.card[data-rarity='rare holo'][data-subtypes^='supporter'] .card__shine,
-.card[data-rarity='rare holo galaxy'][data-subtypes^='supporter'] .card__shine,
-.card[data-rarity='rare holo'][data-subtypes^='supporter'] .card__glare:after,
-.card[data-rarity='rare holo galaxy'][data-subtypes^='supporter'] .card__glare:after {
-	clip-path: inset(14.5% 7.9% 48.2% 8.7%);
+.card[data-rarity="rare holo"][data-subtypes^="supporter"] .card__shine,
+.card[data-rarity="rare holo galaxy"][data-subtypes^="supporter"] .card__shine,
+.card[data-rarity="rare holo"][data-subtypes^="supporter"] .card__glare:after,
+.card[data-rarity="rare holo galaxy"][data-subtypes^="supporter"] .card__glare:after {
+  clip-path: inset(14.5% 7.9% 48.2% 8.7%);
 }
+
+
+
+
 
 /*
 
@@ -240,56 +204,64 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity*='rare holo v'] .card__shine,
-.card[data-rarity*='rare holo v'] .card__shine:after {
-	--space: 5%;
-	--angle: 133deg;
-	--imgsize: 500px;
+.card[data-rarity*="rare holo v"] .card__shine,
+.card[data-rarity*="rare holo v"] .card__shine:after {
 
-	background-image: var(--grain),
-		repeating-linear-gradient(
-			0deg,
-			rgb(255, 119, 115) calc(var(--space) * 1),
-			rgba(255, 237, 95, 1) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgba(120, 148, 255, 1) calc(var(--space) * 5),
-			rgb(216, 117, 255) calc(var(--space) * 6),
-			rgb(255, 119, 115) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			#0e152e 0%,
-			hsl(180, 10%, 60%) 3.8%,
-			hsl(180, 29%, 66%) 4.5%,
-			hsl(180, 10%, 60%) 5.2%,
-			#0e152e 10%,
-			#0e152e 12%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(0, 0, 0, 0.1) 12%,
-			rgba(0, 0, 0, 0.15) 20%,
-			rgba(0, 0, 0, 0.25) 120%
-		);
+  --space: 5%;
+  --angle: 133deg;
+  --imgsize: 500px;
 
-	background-blend-mode: screen, hue, hard-light;
-	background-size: var(--imgsize), 200% 700%, 300%, 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-image:
+    var(--grain),
+    repeating-linear-gradient( 0deg, 
+      rgb(255, 119, 115) calc(var(--space)*1), 
+      rgba(255,237,95,1) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgba(120,148,255,1) calc(var(--space)*5), 
+      rgb(216, 117, 255) calc(var(--space)*6), 
+      rgb(255, 119, 115) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      #0e152e 0%, 
+      hsl(180, 10%, 60%) 3.8%, 
+      hsl(180, 29%, 66%) 4.5%, 
+      hsl(180, 10%, 60%) 5.2%, 
+      #0e152e 10% , 
+      #0e152e 12% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(0, 0, 0, .1) 12%, 
+      rgba(0, 0, 0, .15) 20%, 
+      rgba(0, 0, 0, .25) 120%
+    );
 
-	filter: brightness(0.8) contrast(2.95) saturate(0.5);
+  background-blend-mode: screen, hue, hard-light;
+  background-size: var(--imgsize), 200% 700%, 300%, 200%;
+  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  
+  filter: brightness(.8) contrast(2.95) saturate(.5);
+
 }
 
-.card[data-rarity='rare holo v'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare holo v"] .card__shine:after {
 
-	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
-		var(--posx) var(--posy);
-	background-size: var(--imgsize), 200% 400%, 195%, 200%;
+  content: "";
 
-	filter: brightness(1) contrast(2.5) saturate(1.75);
-	mix-blend-mode: soft-light;
+  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
+  background-size: var(--imgsize), 200% 400%, 195%, 200%;
+
+  filter: brightness(1) contrast(2.5) saturate(1.75);
+  mix-blend-mode: soft-light;
+
 }
+
+
+
+
 
 /*
 
@@ -297,43 +269,53 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo vmax'] .card__shine {
-	--space: 6%;
-	--angle: 133deg;
-	--imgsize: 60% 30%;
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/vmaxbg.webp'),
-		repeating-linear-gradient(
-			-33deg,
-			rgb(206, 42, 36) calc(var(--space) * 1),
-			rgb(157, 170, 223) calc(var(--space) * 2),
-			rgb(45, 153, 146) calc(var(--space) * 3),
-			rgb(29, 151, 36) calc(var(--space) * 4),
-			rgb(181, 64, 228) calc(var(--space) * 5),
-			rgb(206, 42, 36) calc(var(--space) * 6)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			rgba(14, 21, 46, 0.5) 0%,
-			hsl(180, 10%, 50%) 2.5%,
-			hsl(83, 50%, 35%) 5%,
-			hsl(180, 10%, 50%) 7.5%,
-			rgba(14, 21, 46, 0.5) 10%,
-			rgba(14, 21, 46, 0.5) 15%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(6, 218, 255, 0.6) 0%,
-			rgba(38, 235, 127, 0.6) 25%,
-			rgba(155, 78, 228, 0.6) 50%,
-			rgba(228, 78, 90, 0.6) 75%
-		);
+.card[data-rarity="rare holo vmax"] .card__shine {
+  --space: 6%;
+  --angle: 133deg;
+  --imgsize: 60% 30%;
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/vmaxbg.webp"),
+    repeating-linear-gradient( -33deg, 
+      rgb(206, 42, 36) calc(var(--space)*1),  
+      rgb(157, 170, 223) calc(var(--space)*2), 
+      rgb(45, 153, 146) calc(var(--space)*3), 
+      rgb(29, 151, 36) calc(var(--space)*4), 
+      rgb(181, 64, 228) calc(var(--space)*5), 
+      rgb(206, 42, 36) calc(var(--space)*6)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      rgba(14, 21, 46, 0.5) 0%, 
+      hsl(180, 10%, 50%) 2.5%, 
+      hsl(83, 50%, 35%) 5%, 
+      hsl(180, 10%, 50%) 7.5%, 
+      rgba(14, 21, 46, 0.5) 10% , 
+      rgba(14, 21, 46, 0.5) 15% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(6, 218, 255, 0.6) 0%, 
+      rgba(38, 235, 127, 0.6) 25%, 
+      rgba(155, 78, 228, 0.6) 50%, 
+      rgba(228, 78, 90, 0.6) 75%
+    );
 
-	background-blend-mode: color-burn, screen, soft-light;
-	background-size: var(--imgsize), 1100% 1100%, 600% 600%, 200% 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-blend-mode: color-burn, screen, soft-light;
+  background-size: var(--imgsize), 1100% 1100%, 600% 600%, 200% 200%;
+  background-position: 
+    center, 
+    0% var(--posy), 
+    var(--posx) var(--posy), 
+    var(--posx) var(--posy);
 
-	filter: brightness(calc((var(--hyp) * 0.3) + 0.5)) contrast(2.5) saturate(0.6);
+  filter: brightness(calc((var(--hyp)*0.3) + 0.5)) contrast(2.5) saturate(.6);
+
 }
+
+
+
+
 
 /*
 
@@ -341,56 +323,64 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine,
-.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine:after {
-	--space: 5%;
-	--angle: 133deg;
-	--imgsize: 30%;
+.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine,
+.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/ancient.webp'),
-		repeating-linear-gradient(
-			0deg,
-			rgb(255, 119, 115) calc(var(--space) * 1),
-			rgba(255, 237, 95, 1) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgba(120, 148, 255, 1) calc(var(--space) * 5),
-			rgb(216, 117, 255) calc(var(--space) * 6),
-			rgb(255, 119, 115) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			#0e152e 0%,
-			hsl(180, 10%, 60%) 3.8%,
-			hsl(180, 29%, 66%) 4.5%,
-			hsl(180, 10%, 60%) 5.2%,
-			#0e152e 10%,
-			#0e152e 12%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(0, 0, 0, 0.1) 12%,
-			rgba(0, 0, 0, 0.15) 20%,
-			rgba(0, 0, 0, 0.25) 120%
-		);
+  --space: 5%;
+  --angle: 133deg;
+  --imgsize: 30%;
 
-	background-blend-mode: soft-light, hue, hard-light;
-	background-size: var(--imgsize), 200% 700%, 300%, 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/ancient.webp"),
+    repeating-linear-gradient( 0deg, 
+      rgb(255, 119, 115) calc(var(--space)*1), 
+      rgba(255,237,95,1) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgba(120,148,255,1) calc(var(--space)*5), 
+      rgb(216, 117, 255) calc(var(--space)*6), 
+      rgb(255, 119, 115) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      #0e152e 0%, 
+      hsl(180, 10%, 60%) 3.8%, 
+      hsl(180, 29%, 66%) 4.5%, 
+      hsl(180, 10%, 60%) 5.2%, 
+      #0e152e 10% , 
+      #0e152e 12% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(0, 0, 0, .1) 12%, 
+      rgba(0, 0, 0, .15) 20%, 
+      rgba(0, 0, 0, .25) 120%
+    );
 
-	filter: brightness(0.8) contrast(2) saturate(0.75);
+  background-blend-mode: soft-light, hue, hard-light;
+  background-size: var(--imgsize), 200% 700%, 300%, 200%;
+  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  
+  filter: brightness(.8) contrast(2) saturate(.75);
+
 }
 
-.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine:after {
 
-	background-size: var(--imgsize), 200% 400%, 195%, 200%;
-	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
-		var(--posx) var(--posy);
+  content: "";
 
-	filter: brightness(1.2) contrast(1.5) saturate(1.75);
-	mix-blend-mode: exclusion;
+  background-size: var(--imgsize), 200% 400%, 195%, 200%;
+  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
+
+  filter: brightness(1.2) contrast(1.5) saturate(1.75);
+  mix-blend-mode: exclusion;
+
 }
+
+
+
+
 
 /*
 
@@ -398,56 +388,64 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine,
-.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine:after {
-	--space: 5%;
-	--angle: 133deg;
-	--imgsize: 50%;
+.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine,
+.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp'),
-		repeating-linear-gradient(
-			0deg,
-			rgb(255, 119, 115) calc(var(--space) * 1),
-			rgba(255, 237, 95, 1) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgba(120, 148, 255, 1) calc(var(--space) * 5),
-			rgb(216, 117, 255) calc(var(--space) * 6),
-			rgb(255, 119, 115) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			#0e152e 0%,
-			hsl(180, 10%, 60%) 3.8%,
-			hsl(180, 29%, 66%) 4.5%,
-			hsl(180, 10%, 60%) 5.2%,
-			#0e152e 10%,
-			#0e152e 12%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(0, 0, 0, 0.1) 12%,
-			rgba(0, 0, 0, 0.15) 20%,
-			rgba(0, 0, 0, 0.25) 120%
-		);
+  --space: 5%;
+  --angle: 133deg;
+  --imgsize: 50%;
 
-	background-blend-mode: exclusion, hue, hard-light;
-	background-size: var(--imgsize), 200% 700%, 300%, 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp"),
+    repeating-linear-gradient( 0deg, 
+      rgb(255, 119, 115) calc(var(--space)*1), 
+      rgba(255,237,95,1) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgba(120,148,255,1) calc(var(--space)*5), 
+      rgb(216, 117, 255) calc(var(--space)*6), 
+      rgb(255, 119, 115) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      #0e152e 0%, 
+      hsl(180, 10%, 60%) 3.8%, 
+      hsl(180, 29%, 66%) 4.5%, 
+      hsl(180, 10%, 60%) 5.2%, 
+      #0e152e 10% , 
+      #0e152e 12% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(0, 0, 0, .1) 12%, 
+      rgba(0, 0, 0, .15) 20%, 
+      rgba(0, 0, 0, .25) 120%
+    );
 
-	filter: brightness(calc((var(--hyp) * 0.3) + 0.5)) contrast(2) saturate(1.5);
+  background-blend-mode: exclusion, hue, hard-light;
+  background-size: var(--imgsize), 200% 700%, 300%, 200%;
+  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+
+  filter: brightness(calc((var(--hyp)*0.3) + 0.5)) contrast(2) saturate(1.5);
+
 }
 
-.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine:after {
 
-	background-size: var(--imgsize), 200% 400%, 195%, 200%;
-	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
-		var(--posx) var(--posy);
+  content: "";
 
-	filter: brightness(calc((var(--hyp) * 0.5) + 0.8)) contrast(1.6) saturate(1.4);
-	mix-blend-mode: exclusion;
+  background-size: var(--imgsize), 200% 400%, 195%, 200%;
+  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
+
+  filter: brightness(calc((var(--hyp)*0.5) + .8)) contrast(1.6) saturate(1.4);
+  mix-blend-mode: exclusion;
+
 }
+
+
+
+
 
 /*
 
@@ -455,56 +453,64 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine,
-.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine:after {
-	--space: 5%;
-	--angle: 133deg;
-	--imgsize: 50%;
+.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine,
+.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/trainerbg.jpg'),
-		repeating-linear-gradient(
-			0deg,
-			rgb(255, 119, 115) calc(var(--space) * 1),
-			rgba(255, 237, 95, 1) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgba(120, 148, 255, 1) calc(var(--space) * 5),
-			rgb(216, 117, 255) calc(var(--space) * 6),
-			rgb(255, 119, 115) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			#0e152e 0%,
-			hsl(180, 10%, 60%) 3.8%,
-			hsl(180, 29%, 66%) 4.5%,
-			hsl(180, 10%, 60%) 5.2%,
-			#0e152e 10%,
-			#0e152e 12%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(0, 0, 0, 0.1) 12%,
-			rgba(0, 0, 0, 0.15) 20%,
-			rgba(0, 0, 0, 0.25) 120%
-		);
+  --space: 5%;
+  --angle: 133deg;
+  --imgsize: 50%;
 
-	background-blend-mode: difference, hue, hard-light;
-	background-size: var(--imgsize), 200% 700%, 300%, 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-image:
+  url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/trainerbg.jpg"),
+    repeating-linear-gradient( 0deg, 
+      rgb(255, 119, 115) calc(var(--space)*1), 
+      rgba(255,237,95,1) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgba(120,148,255,1) calc(var(--space)*5), 
+      rgb(216, 117, 255) calc(var(--space)*6), 
+      rgb(255, 119, 115) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      #0e152e 0%, 
+      hsl(180, 10%, 60%) 3.8%, 
+      hsl(180, 29%, 66%) 4.5%, 
+      hsl(180, 10%, 60%) 5.2%, 
+      #0e152e 10% , 
+      #0e152e 12% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(0, 0, 0, .1) 12%, 
+      rgba(0, 0, 0, .15) 20%, 
+      rgba(0, 0, 0, .25) 120%
+    );
 
-	filter: brightness(0.75) contrast(2.5) saturate(0.75);
+  background-blend-mode: difference, hue, hard-light;
+  background-size: var(--imgsize), 200% 700%, 300%, 200%;
+  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+
+  filter: brightness(0.75) contrast(2.5) saturate(.75);
+  
 }
 
-.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine:after {
 
-	background-size: var(--imgsize), 200% 400%, 195%, 200%;
-	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
-		var(--posx) var(--posy);
+  content: "";
 
-	filter: brightness(1.2) contrast(1) saturate(1.75);
-	mix-blend-mode: exclusion;
+  background-size: var(--imgsize), 200% 400%, 195%, 200%;
+  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
+
+  filter: brightness(1.2) contrast(1) saturate(1.75);
+  mix-blend-mode: exclusion;
+
 }
+
+
+
+
 
 /*
 
@@ -512,49 +518,52 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity^='rare rainbow'] .card__shine,
-.card[data-rarity^='rare rainbow'] .card__shine:after {
-	--space: 7%;
-	--angle: -20deg;
-	--angle2: 130deg;
-	--imgsize: 540px 700px;
+.card[data-rarity^="rare rainbow"] .card__shine,
+.card[data-rarity^="rare rainbow"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
-		repeating-linear-gradient(
-			var(--angle),
-			rgb(253, 71, 65) calc(var(--space) * 1),
-			rgb(255, 243, 151) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgb(75, 198, 255) calc(var(--space) * 5),
-			rgb(255, 73, 246) calc(var(--space) * 6),
-			rgb(255, 56, 49) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle2),
-			rgba(89, 46, 80, 0.5) 0%,
-			hsl(118, 43%, 76%) 2.5%,
-			rgb(223, 96, 202) 5%,
-			hsl(180, 57%, 56%) 7.5%,
-			rgba(14, 21, 46, 0.5) 10%,
-			rgba(14, 21, 46, 0.5) 15%
-		),
-		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion2.webp');
+  --space: 7%;
+  --angle: -20deg;
+  --angle2: 130deg;
+  --imgsize: 540px 700px;
 
-	background-size: 50% 50%, 500% 500%, 1000% 1000%, var(--imgsize);
-	background-position: center, 0% calc(var(--posy) * 1.5), var(--posx) var(--posy), center;
-	background-blend-mode: color-burn, soft-light, normal;
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
+    repeating-linear-gradient( var(--angle), 
+      rgb(253, 71, 65) calc(var(--space)*1), 
+      rgb(255, 243, 151) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgb(75, 198, 255) calc(var(--space)*5), 
+      rgb(255, 73, 246) calc(var(--space)*6), 
+      rgb(255, 56, 49) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( var(--angle2), 
+      rgba(89, 46, 80, 0.5) 0%, 
+      hsl(118, 43%, 76%) 2.5%, 
+      rgb(223, 96, 202) 5%, 
+      hsl(180, 57%, 56%) 7.5%, 
+      rgba(14, 21, 46, 0.5) 10% , 
+      rgba(14, 21, 46, 0.5) 15% 
+    ),
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion2.webp");
 
-	filter: brightness(calc((var(--hyp) * 0.25) + 0.66)) contrast(2) saturate(0.95);
+  background-size: 50% 50%, 500% 500%, 1000% 1000%, var(--imgsize);
+  background-position: center, 0% calc( var(--posy) * 1.5 ), var(--posx) var(--posy), center;
+  background-blend-mode: color-burn, soft-light, normal;
+
+  filter: brightness(calc((var(--hyp)*0.25) + 0.66)) contrast(2) saturate(.95);
+
 }
 
-.card[data-rarity^='rare rainbow'] .card__shine:after {
-	content: '';
+.card[data-rarity^="rare rainbow"] .card__shine:after {
 
-	background-position: center, 0% calc(var(--posy) * -1),
-		calc(var(--posx) * -1) calc(var(--posy) * -1), center;
-	mix-blend-mode: exclusion;
+  content: "";
+
+  background-position: center, 0% calc( var(--posy) * -1 ), calc( var(--posx) * -1 ) calc( var(--posy) * -1 ), center;
+  mix-blend-mode: exclusion;
+
 }
+
 
 /*
 
@@ -562,10 +571,15 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare rainbow alt'] .card__shine,
-.card[data-rarity='rare rainbow alt'] .card__shine:after {
-	filter: brightness(calc((var(--hyp) * 0.25) + 0.66)) contrast(3) saturate(0.7);
+.card[data-rarity="rare rainbow alt"] .card__shine,
+.card[data-rarity="rare rainbow alt"] .card__shine:after {
+
+  filter: brightness(calc((var(--hyp)*0.25) + 0.66)) contrast(3) saturate(.7);
+
 }
+
+
+
 
 /*
 
@@ -573,49 +587,58 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare secret'] .card__shine,
-.card[data-rarity='rare secret'] .card__shine:after {
-	--angle: 110deg;
-	--imgsize: 250px;
+.card[data-rarity="rare secret"] .card__shine,
+.card[data-rarity="rare secret"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
-		repeating-linear-gradient(
-			var(--angle),
-			rgba(89, 46, 80, 0.5) 0%,
-			hsl(39, 37%, 60%) 2.5%,
-			rgb(216, 183, 92) 5%,
-			hsl(39, 37%, 60%) 7.5%,
-			rgba(14, 21, 46, 0.5) 10%,
-			rgba(14, 21, 46, 0.5) 15%
-		),
-		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/metal.webp');
+  --angle: 110deg;
+  --imgsize: 250px;
 
-	background-size: 50% 50%, 600% 600%, var(--imgsize);
-	background-position: center, var(--posx) var(--posy), center;
-	background-blend-mode: color-burn, darken;
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
+    repeating-linear-gradient( var(--angle), 
+      rgba(89, 46, 80, 0.5) 0%, 
+      hsl(39, 37%, 60%) 2.5%, 
+      rgb(216, 183, 92) 5%, 
+      hsl(39, 37%, 60%) 7.5%, 
+      rgba(14, 21, 46, 0.5) 10% , 
+      rgba(14, 21, 46, 0.5) 15% 
+    ), 
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/metal.webp");
 
-	filter: brightness(calc((var(--hyp) * 0.4) + 0.7)) contrast(3) saturate(0.66);
+  background-size: 50% 50%, 600% 600%, var(--imgsize);
+  background-position: center, var(--posx) var(--posy), center;
+  background-blend-mode: color-burn, darken;
+
+  filter: brightness(calc((var(--hyp)*0.4) + 0.7)) contrast(3) saturate(.66);
+
+
 }
 
-.card[data-rarity='rare secret'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare secret"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
-		repeating-linear-gradient(
-			var(--angle),
-			rgba(89, 46, 80, 0.5) 0%,
-			hsl(39, 37%, 60%) 2.5%,
-			rgb(216, 183, 92) 5%,
-			hsl(39, 37%, 60%) 7.5%,
-			rgba(14, 21, 46, 0.5) 10%,
-			rgba(14, 21, 46, 0.5) 15%
-		);
+  content: "";
 
-	background-position: center, calc(var(--posx) * -1) calc(var(--posy) * -1), center;
+  background-image:
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
+    repeating-linear-gradient( var(--angle), 
+      rgba(89, 46, 80, 0.5) 0%, 
+      hsl(39, 37%, 60%) 2.5%, 
+      rgb(216, 183, 92) 5%, 
+      hsl(39, 37%, 60%) 7.5%, 
+      rgba(14, 21, 46, 0.5) 10% , 
+      rgba(14, 21, 46, 0.5) 15% 
+    );
 
-	filter: brightness(calc((var(--hyp) * 0.3) + 0.7)) contrast(2.5) saturate(0.66);
-	mix-blend-mode: exclusion;
+  background-position: center, calc( var(--posx) * -1 ) calc( var(--posy) * -1 ), center;
+
+  filter: brightness(calc((var(--hyp)*0.3) + 0.7)) contrast(2.5) saturate(.66);
+  mix-blend-mode: exclusion;
+
 }
+
+
+
+
 
 /*
 
@@ -623,126 +646,137 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity*='radiant'] .card__shine {
-	--barwidth: 1.2%;
-	--space: 200px;
+.card[data-rarity*="radiant"] .card__shine {
 
-	opacity: calc(((var(--hyp) * 0.7) + 0.2) * var(--o)) !important;
-	clip-path: inset(2.8% 4% round 2.55% / 1.5%);
+  --barwidth: 1.2%;
+  --space: 200px;
 
-	background-image: repeating-linear-gradient(
-			55deg,
-			rgb(255, 161, 158) calc(var(--space) * 1),
-			rgb(85, 178, 255) calc(var(--space) * 2),
-			rgb(255, 199, 146) calc(var(--space) * 3),
-			rgb(130, 255, 213) calc(var(--space) * 4),
-			rgb(253, 170, 240) calc(var(--space) * 5),
-			rgb(148, 241, 255) calc(var(--space) * 6),
-			rgb(255, 161, 158) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			45deg,
-			hsl(0, 0%, 10%) 0%,
-			hsl(0, 0%, 10%) 1%,
-			hsl(0, 0%, 10%) var(--barwidth),
-			hsl(0, 0%, 20%) calc(var(--barwidth) + 0.01%),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 2),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 2 + 0.01%),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 3),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 3 + 0.01%),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 4),
-			hsl(0, 0%, 50%) calc(var(--barwidth) * 4 + 0.01%),
-			hsl(0, 0%, 50%) calc(var(--barwidth) * 5),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 5 + 0.01%),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 6),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 6 + 0.01%),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 7),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 7 + 0.01%),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 8),
-			hsl(0, 0%, 10%) calc(var(--barwidth) * 8 + 0.01%),
-			hsl(0, 0%, 10%) calc(var(--barwidth) * 9),
-			hsl(0, 0%, 0%) calc(var(--barwidth) * 9 + 0.01%),
-			hsl(0, 0%, 0%) calc(var(--barwidth) * 10)
-		),
-		repeating-linear-gradient(
-			-45deg,
-			hsl(0, 0%, 10%) 0%,
-			hsl(0, 0%, 10%) 1%,
-			hsl(0, 0%, 10%) var(--barwidth),
-			hsl(0, 0%, 20%) calc(var(--barwidth) + 0.01%),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 2),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 2 + 0.01%),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 3),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 3 + 0.01%),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 4),
-			hsl(0, 0%, 50%) calc(var(--barwidth) * 4 + 0.01%),
-			hsl(0, 0%, 50%) calc(var(--barwidth) * 5),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 5 + 0.01%),
-			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 6),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 6 + 0.01%),
-			hsl(0, 0%, 35%) calc(var(--barwidth) * 7),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 7 + 0.01%),
-			hsl(0, 0%, 20%) calc(var(--barwidth) * 8),
-			hsl(0, 0%, 10%) calc(var(--barwidth) * 8 + 0.01%),
-			hsl(0, 0%, 10%) calc(var(--barwidth) * 9),
-			hsl(0, 0%, 0%) calc(var(--barwidth) * 9 + 0.01%),
-			hsl(0, 0%, 0%) calc(var(--barwidth) * 10)
-		);
+  opacity: calc( ((var(--hyp)*0.7) + 0.2) * var(--o) ) !important;
+  clip-path: inset(2.8% 4% round 2.55% / 1.5%);
 
-	background-size: 400% 400%, 210% 210%, 210% 210%;
-	background-position: calc(((var(--posx) - 50%) * -2.5) + 50%)
-			calc(((var(--posy) - 50%) * -2.5) + 50%),
-		calc(((var(--posx) - 50%) * 1.5) + 50%) calc(((var(--posy) - 50%) * 1.5) + 50%),
-		calc(((var(--posx) - 50%) * 1.5) + 50%) calc(((var(--posy) - 50%) * 1.5) + 50%);
+  background-image: 
+    repeating-linear-gradient( 55deg, 
+      rgb(255, 161, 158) calc(var(--space)*1), 
+      rgb(85, 178, 255) calc(var(--space)*2), 
+      rgb(255, 199, 146) calc(var(--space)*3), 
+      rgb(130, 255, 213) calc(var(--space)*4), 
+      rgb(253, 170, 240) calc(var(--space)*5), 
+      rgb(148, 241, 255) calc(var(--space)*6), 
+      rgb(255, 161, 158) calc(var(--space)*7) 
+    ),
+    repeating-linear-gradient( 
+      45deg, 
+      hsl(0,0%,10%) 0% ,  
+      hsl(0,0%,10%) 1% , 
+      hsl(0,0%,10%) var(--barwidth),
+      hsl(0,0%,20%) calc( var(--barwidth) + 0.01% ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 2 ),
+      hsl(0,0%,35%) calc( var(--barwidth) * 2 + 0.01% ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 3 ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 3 + 0.01% ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 4 ) ,
+      hsl(0,0%,50%) calc( var(--barwidth) * 4 + 0.01% ) ,
+      hsl(0,0%,50%) calc( var(--barwidth) * 5 ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 5 + 0.01% ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 6 ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 6 + 0.01% ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 7 ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 7 + 0.01% ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 8 )  ,
+      hsl(0,0%,10%) calc( var(--barwidth) * 8 + 0.01% ) ,
+      hsl(0,0%,10%) calc( var(--barwidth) * 9 )  ,
+      hsl(0,0%,0%) calc( var(--barwidth) * 9 + 0.01% ) ,
+      hsl(0,0%,0%) calc( var(--barwidth) * 10 ) 
+    ),
+    repeating-linear-gradient( 
+      -45deg, 
+      hsl(0,0%,10%) 0% ,  
+      hsl(0,0%,10%) 1% , 
+      hsl(0,0%,10%) var(--barwidth),
+      hsl(0,0%,20%) calc( var(--barwidth) + 0.01% ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 2 ),
+      hsl(0,0%,35%) calc( var(--barwidth) * 2 + 0.01% ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 3 ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 3 + 0.01% ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 4 ) ,
+      hsl(0,0%,50%) calc( var(--barwidth) * 4 + 0.01% ) ,
+      hsl(0,0%,50%) calc( var(--barwidth) * 5 ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 5 + 0.01% ) ,
+      hsl(0,0%,42.5%) calc( var(--barwidth) * 6 ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 6 + 0.01% ) ,
+      hsl(0,0%,35%) calc( var(--barwidth) * 7 ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 7 + 0.01% ) ,
+      hsl(0,0%,20%) calc( var(--barwidth) * 8 )  ,
+      hsl(0,0%,10%) calc( var(--barwidth) * 8 + 0.01% ) ,
+      hsl(0,0%,10%) calc( var(--barwidth) * 9 )  ,
+      hsl(0,0%,0%) calc( var(--barwidth) * 9 + 0.01% ) ,
+      hsl(0,0%,0%) calc( var(--barwidth) * 10 ) 
+    );
 
-	background-blend-mode: exclusion, darken, color-dodge;
+  background-size: 400% 400%, 210% 210%, 210% 210%;
+  background-position: 
+    calc( ((var(--posx) - 50%) * -2.5) + 50% ) calc( ((var(--posy) - 50%) * -2.5) + 50% ), 
+    calc( ((var(--posx) - 50%) * 1.5) + 50% ) calc( ((var(--posy) - 50%) * 1.5) + 50% ), 
+    calc( ((var(--posx) - 50%) * 1.5) + 50% ) calc( ((var(--posy) - 50%) * 1.5) + 50% );
 
-	filter: brightness(0.95) contrast(4) saturate(0.75);
-	mix-blend-mode: color-dodge;
+  background-blend-mode: exclusion, darken, color-dodge;
+
+  filter: brightness(.95) contrast(4) saturate(0.75);
+  mix-blend-mode: color-dodge;
+
 }
 
-.card[data-rarity*='radiant'] .card__shine:after {
-	content: '';
+.card[data-rarity*="radiant"] .card__shine:after {
 
-	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
-		repeating-linear-gradient(
-			55deg,
-			rgb(255, 161, 158) calc(var(--space) * 1),
-			rgb(85, 178, 255) calc(var(--space) * 2),
-			rgb(255, 199, 146) calc(var(--space) * 3),
-			rgb(130, 255, 213) calc(var(--space) * 4),
-			rgb(253, 170, 240) calc(var(--space) * 5),
-			rgb(148, 241, 255) calc(var(--space) * 6),
-			rgb(255, 161, 158) calc(var(--space) * 7)
-		);
+  content: "";
 
-	background-size: 40%, 400%;
-	background-position: center,
-		calc(((var(--posx) - 50%) * -2.5) + 50%) calc(((var(--posy) - 50%) * -2.5) + 50%);
+  background-image: 
+    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"), 
+    repeating-linear-gradient( 55deg, 
+    rgb(255, 161, 158) calc(var(--space)*1), 
+    rgb(85, 178, 255) calc(var(--space)*2), 
+    rgb(255, 199, 146) calc(var(--space)*3), 
+    rgb(130, 255, 213) calc(var(--space)*4), 
+    rgb(253, 170, 240) calc(var(--space)*5), 
+    rgb(148, 241, 255) calc(var(--space)*6), 
+    rgb(255, 161, 158) calc(var(--space)*7) 
+  );
 
-	filter: brightness(1) contrast(1) saturate(0);
-	mix-blend-mode: soft-light;
+  background-size: 40%, 400%;
+  background-position: center, calc( ((var(--posx) - 50%) * -2.5) + 50% ) calc( ((var(--posy) - 50%) * -2.5) + 50% );
+  
+  filter: brightness(1) contrast(1) saturate(0);
+  mix-blend-mode: soft-light;
 
-	background-blend-mode: multiply;
+  background-blend-mode: multiply;
+  
 }
 
-.card[data-rarity*='radiant'] .card__shine:before {
-	content: '';
-	z-index: 3;
-	grid-area: 1/1;
+.card[data-rarity*="radiant"] .card__shine:before {
+  
+  content: "";
+  z-index: 3;
+  grid-area: 1/1;
 
-	background-image: radial-gradient(
-		farthest-corner ellipse at calc(((var(--mx)) * 0.5) + 25%) calc(((var(--my)) * 0.5) + 25%),
-		rgba(100, 100, 100, 0.5) 5%,
-		rgba(50, 50, 50, 0.4) 15%,
-		rgba(0, 0, 0, 0.6) 30%
-	);
+  background-image:
+    radial-gradient(
+      farthest-corner ellipse 
+      at calc( ((var(--mx)) * 0.5) + 25% ) calc( ((var(--my)) * 0.5) + 25% ),
+      rgba(100, 100, 100, .5) 5%, 
+      rgba(50, 50, 50, .4) 15%, 
+      rgba(0, 0, 0, .6) 30%
+    );
 
-	background-position: center;
-	background-size: 350% 350%;
+  background-position: center;
+  background-size: 350% 350%;
 
-	mix-blend-mode: multiply;
+  mix-blend-mode: multiply;
+
 }
+
+
+
+
 
 /*
 
@@ -750,47 +784,57 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo'][data-gallery='true'] .card__shine {
-	--space: 5%;
-	--angle: -22deg;
-	--imgsize: 200% 400%;
+.card[data-rarity="rare holo"][data-gallery="true"] .card__shine {
 
-	clip-path: inset(2.8% 4% round 2.55% / 1.5%);
+  --space: 5%;
+  --angle: -22deg;
+  --imgsize: 200% 400%;
 
-	background-image: repeating-linear-gradient(
-		var(--angle),
-		rgba(174, 102, 202, 0.75) calc(var(--space) * 1),
-		rgba(228, 77, 72, 0.75) calc(var(--space) * 2),
-		rgba(216, 197, 55, 0.75) calc(var(--space) * 3),
-		rgba(124, 201, 62, 0.75) calc(var(--space) * 4),
-		rgba(80, 177, 170, 0.75) calc(var(--space) * 5),
-		rgba(136, 160, 255, 0.75) calc(var(--space) * 6),
-		rgba(176, 105, 204, 0.75) calc(var(--space) * 7)
-	);
+  clip-path: inset(2.8% 4% round 2.55% / 1.5%);
 
-	background-blend-mode: color-dodge;
-	background-size: var(--imgsize), 300%, 200%;
-	background-position: 0% calc(var(--posy) * 1), var(--posx) var(--posy);
+  background-image:
+    repeating-linear-gradient( var(--angle),  
+      rgba(174, 102, 202, 0.75) calc(var(--space)*1),
+      rgba(228, 77, 72, 0.75) calc(var(--space)*2), 
+      rgba(216, 197, 55, 0.75) calc(var(--space)*3),  
+      rgba(124, 201, 62, 0.75) calc(var(--space)*4),  
+      rgba(80, 177, 170, 0.75) calc(var(--space)*5),  
+      rgba(136, 160, 255, 0.75) calc(var(--space)*6), 
+      rgba(176, 105, 204, 0.75) calc(var(--space)*7)
+    );
+    
+    background-blend-mode: color-dodge;
+    background-size: var(--imgsize), 300%, 200%;
+    background-position: 0% calc(var(--posy) * 1), var(--posx) var(--posy);
+    
+    filter: brightness(calc((var(--hyp)*0.3) + 0.6)) contrast(2.3) saturate(1.1);
 
-	filter: brightness(calc((var(--hyp) * 0.3) + 0.6)) contrast(2.3) saturate(1.1);
 }
 
-.card[data-rarity='rare holo'][data-gallery='true'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare holo"][data-gallery="true"] .card__shine:after {
+  
+  content: "";
 
-	background-image: radial-gradient(
-		farthest-corner ellipse at calc(((var(--mx)) * 0.5) + 25%) calc(((var(--my)) * 0.5) + 25%),
-		rgb(255, 255, 255) 5%,
-		rgba(55, 0, 55, 0.6) 25%,
-		rgb(55, 55, 55) 90%
-	);
+  background-image: 
+    radial-gradient( 
+      farthest-corner ellipse 
+      at calc( ((var(--mx)) * 0.5) + 25% ) calc( ((var(--my)) * 0.5) + 25% ), 
+      rgb(255, 255, 255) 5%, 
+      rgba(55, 0, 55, .6) 25%, 
+      rgb(55, 55, 55) 90% 
+    );
 
-	background-position: center;
-	background-size: 200% 200%;
+  background-position: center;
+  background-size: 200% 200%;
 
-	filter: brightness(calc((var(--hyp) * 0.2) + 0.4)) contrast(0.85) saturate(1.1);
-	mix-blend-mode: hard-light;
+  filter: brightness(calc((var(--hyp)*0.2) + 0.4)) contrast(.85) saturate(1.1);
+  mix-blend-mode: hard-light;
+
 }
+
+
+
+
 
 /*
 
@@ -798,60 +842,67 @@ button[class^='card'] {
 
 */
 
-.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine,
-.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine:after {
-	--space: 5%;
-	--angle: 133deg;
-	--img: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp');
-	--imgsize: 60%;
+.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine,
+.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine:after {
 
-	background-image: var(--img),
-		repeating-linear-gradient(
-			0deg,
-			rgb(255, 119, 115) calc(var(--space) * 1),
-			rgba(255, 237, 95, 1) calc(var(--space) * 2),
-			rgba(168, 255, 95, 1) calc(var(--space) * 3),
-			rgba(131, 255, 247, 1) calc(var(--space) * 4),
-			rgba(120, 148, 255, 1) calc(var(--space) * 5),
-			rgb(216, 117, 255) calc(var(--space) * 6),
-			rgb(255, 119, 115) calc(var(--space) * 7)
-		),
-		repeating-linear-gradient(
-			var(--angle),
-			#0e152e 0%,
-			hsl(180, 10%, 60%) 3.8%,
-			hsl(180, 29%, 66%) 4.5%,
-			hsl(180, 10%, 60%) 5.2%,
-			#0e152e 10%,
-			#0e152e 12%
-		),
-		radial-gradient(
-			farthest-corner circle at var(--mx) var(--my),
-			rgba(0, 0, 0, 0.1) 12%,
-			rgba(0, 0, 0, 0.15) 20%,
-			rgba(0, 0, 0, 0.25) 120%
-		);
+  --space: 5%;
+  --angle: 133deg;
+  --img: url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp");
+  --imgsize: 60%;
 
-	background-blend-mode: exclusion, hue, hard-light;
-	background-size: var(--imgsize), 200% 700%, 300%, 200%;
-	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+  background-image:
+    var(--img),
+    repeating-linear-gradient( 0deg, 
+      rgb(255, 119, 115) calc(var(--space)*1), 
+      rgba(255,237,95,1) calc(var(--space)*2), 
+      rgba(168,255,95,1) calc(var(--space)*3), 
+      rgba(131,255,247,1) calc(var(--space)*4), 
+      rgba(120,148,255,1) calc(var(--space)*5), 
+      rgb(216, 117, 255) calc(var(--space)*6), 
+      rgb(255, 119, 115) calc(var(--space)*7)
+    ),
+    repeating-linear-gradient( 
+      var(--angle), 
+      #0e152e 0%, 
+      hsl(180, 10%, 60%) 3.8%, 
+      hsl(180, 29%, 66%) 4.5%, 
+      hsl(180, 10%, 60%) 5.2%, 
+      #0e152e 10% , 
+      #0e152e 12% 
+      ),
+    radial-gradient(
+      farthest-corner circle 
+      at var(--mx) var(--my),
+      rgba(0, 0, 0, .1) 12%, 
+      rgba(0, 0, 0, .15) 20%, 
+      rgba(0, 0, 0, .25) 120%
+    );
 
-	filter: brightness(calc((var(--hyp) * 0.4) + 0.5)) contrast(2.5) saturate(1);
+  background-blend-mode: exclusion, hue, hard-light;
+  background-size: var(--imgsize), 200% 700%, 300%, 200%;
+  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
+
+  filter: brightness(calc((var(--hyp)*0.4) + .5)) contrast(2.5) saturate(1);
+
 }
 
-.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine:after {
-	content: '';
+.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine:after {
 
-	background-size: var(--imgsize), 200% 400%, 195%, 200%;
-	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
-		var(--posx) var(--posy);
+  content: "";
 
-	filter: brightness(calc((var(--hyp) * 0.5) + 0.7)) contrast(2) saturate(1);
-	mix-blend-mode: exclusion;
+  background-size: var(--imgsize), 200% 400%, 195%, 200%;
+  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
+
+  filter: brightness(calc((var(--hyp)*0.5) + .7)) contrast(2) saturate(1);
+  mix-blend-mode: exclusion;
+
 }
 
-.card[data-rarity='rare holo v'][data-gallery='true'][data-subtypes*='vmax'] .card__shine,
-.card[data-rarity='rare holo v'][data-gallery='true'][data-subtypes*='vmax'] .card__shine:after {
-	--img: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/stylish.webp');
-	--imgsize: 48%;
+
+.card[data-rarity="rare holo v"][data-gallery="true"][data-subtypes*="vmax"] .card__shine,
+.card[data-rarity="rare holo v"][data-gallery="true"][data-subtypes*="vmax"] .card__shine:after {
+
+    --img: url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/stylish.webp");
+    --imgsize: 48%;
+
 }

--- a/static/cards.css
+++ b/static/cards.css
@@ -1,21 +1,22 @@
-
 .card__shine {
+	--grain: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCI+CjxmaWx0ZXIgaWQ9Im4iPgo8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iLjciIG51bU9jdGF2ZXM9IjEwIiBzdGl0Y2hUaWxlcz0ic3RpdGNoIj48L2ZlVHVyYnVsZW5jZT4KPC9maWx0ZXI+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjMDAwIj48L3JlY3Q+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWx0ZXI9InVybCgjbikiIG9wYWNpdHk9IjAuMyI+PC9yZWN0Pgo8L3N2Zz4=');
 
-  --grain: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCI+CjxmaWx0ZXIgaWQ9Im4iPgo8ZmVUdXJidWxlbmNlIHR5cGU9ImZyYWN0YWxOb2lzZSIgYmFzZUZyZXF1ZW5jeT0iLjciIG51bU9jdGF2ZXM9IjEwIiBzdGl0Y2hUaWxlcz0ic3RpdGNoIj48L2ZlVHVyYnVsZW5jZT4KPC9maWx0ZXI+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWxsPSIjMDAwIj48L3JlY3Q+CjxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiBmaWx0ZXI9InVybCgjbikiIG9wYWNpdHk9IjAuMyI+PC9yZWN0Pgo8L3N2Zz4=");
-  
-  --space: 5%;
-  --angle: 133deg;
-  --imgsize: 500px;
+	--space: 5%;
+	--angle: 133deg;
+	--imgsize: 500px;
 
-  --red: #f80e7b;
-  --yel: #eedf10;
-  --gre: #21e985;
-  --blu: #0dbde9;
-  --vio: #c929f1;
-
+	--red: #f80e7b;
+	--yel: #eedf10;
+	--gre: #21e985;
+	--blu: #0dbde9;
+	--vio: #c929f1;
 }
 
-
+button[class^='card'] {
+	border: none;
+	background: transparent;
+	padding: 0;
+}
 
 /*
 
@@ -23,83 +24,125 @@
 
 */
 
-.card[data-rarity="rare holo"] .card__shine {
+.card[data-rarity='rare holo'] .card__shine {
+	--space: 2px;
+	--h: 21;
+	--s: 70%;
+	--l: 50%;
+	--bars: 24px;
+	--bar-color: rgba(255, 255, 255, 0.6);
+	--bar-bg: rgb(10, 10, 10);
 
-  --space: 2px;
-  --h: 21;
-  --s: 70%;
-  --l: 50%;
-  --bars: 24px;
-  --bar-color: rgba(255, 255, 255, 0.6);
-  --bar-bg: rgb(10, 10, 10);
+	clip-path: inset(10% 8.5% 52.5% 8.5%);
 
-  clip-path: inset( 10% 8.5% 52.5% 8.5% );
+	background-image: repeating-linear-gradient(
+			90deg,
+			hsl(calc(var(--h) * 0), var(--s), var(--l)) calc(var(--space) * 0),
+			hsl(calc(var(--h) * 0), var(--s), var(--l)) calc(var(--space) * 1),
+			black calc(var(--space) * 1.001),
+			black calc(var(--space) * 1.999),
+			hsl(calc(var(--h) * 1), var(--s), var(--l)) calc(var(--space) * 2),
+			hsl(calc(var(--h) * 1), var(--s), var(--l)) calc(var(--space) * 3),
+			black calc(var(--space) * 3.001),
+			black calc(var(--space) * 3.999),
+			hsl(calc(var(--h) * 2), var(--s), var(--l)) calc(var(--space) * 4),
+			hsl(calc(var(--h) * 2), var(--s), var(--l)) calc(var(--space) * 5),
+			black calc(var(--space) * 5.001),
+			black calc(var(--space) * 5.999),
+			hsl(calc(var(--h) * 3), var(--s), var(--l)) calc(var(--space) * 6),
+			hsl(calc(var(--h) * 3), var(--s), var(--l)) calc(var(--space) * 7),
+			black calc(var(--space) * 7.001),
+			black calc(var(--space) * 7.999),
+			hsl(calc(var(--h) * 4), var(--s), var(--l)) calc(var(--space) * 8),
+			hsl(calc(var(--h) * 4), var(--s), var(--l)) calc(var(--space) * 9),
+			black calc(var(--space) * 9.001),
+			black calc(var(--space) * 9.999),
+			hsl(calc(var(--h) * 5), var(--s), var(--l)) calc(var(--space) * 10),
+			hsl(calc(var(--h) * 5), var(--s), var(--l)) calc(var(--space) * 11),
+			black calc(var(--space) * 11.001),
+			black calc(var(--space) * 11.999),
+			hsl(calc(var(--h) * 6), var(--s), var(--l)) calc(var(--space) * 12),
+			hsl(calc(var(--h) * 6), var(--s), var(--l)) calc(var(--space) * 13),
+			black calc(var(--space) * 13.001),
+			black calc(var(--space) * 13.999),
+			hsl(calc(var(--h) * 7), var(--s), var(--l)) calc(var(--space) * 14),
+			hsl(calc(var(--h) * 7), var(--s), var(--l)) calc(var(--space) * 15),
+			black calc(var(--space) * 15.001),
+			black calc(var(--space) * 15.999),
+			hsl(calc(var(--h) * 8), var(--s), var(--l)) calc(var(--space) * 16),
+			hsl(calc(var(--h) * 8), var(--s), var(--l)) calc(var(--space) * 17),
+			black calc(var(--space) * 17.001),
+			black calc(var(--space) * 17.999),
+			hsl(calc(var(--h) * 9), var(--s), var(--l)) calc(var(--space) * 18),
+			hsl(calc(var(--h) * 9), var(--s), var(--l)) calc(var(--space) * 19),
+			black calc(var(--space) * 19.001),
+			black calc(var(--space) * 19.999),
+			hsl(calc(var(--h) * 10), var(--s), var(--l)) calc(var(--space) * 20),
+			hsl(calc(var(--h) * 10), var(--s), var(--l)) calc(var(--space) * 21),
+			black calc(var(--space) * 21.001),
+			black calc(var(--space) * 21.999),
+			hsl(calc(var(--h) * 11), var(--s), var(--l)) calc(var(--space) * 22),
+			hsl(calc(var(--h) * 11), var(--s), var(--l)) calc(var(--space) * 23),
+			black calc(var(--space) * 23.001),
+			black calc(var(--space) * 23.999),
+			hsl(calc(var(--h) * 12), var(--s), var(--l)) calc(var(--space) * 24),
+			hsl(calc(var(--h) * 12), var(--s), var(--l)) calc(var(--space) * 25),
+			black calc(var(--space) * 25.001),
+			black calc(var(--space) * 25.999),
+			hsl(calc(var(--h) * 13), var(--s), var(--l)) calc(var(--space) * 26),
+			hsl(calc(var(--h) * 13), var(--s), var(--l)) calc(var(--space) * 27),
+			black calc(var(--space) * 27.001),
+			black calc(var(--space) * 27.999),
+			hsl(calc(var(--h) * 14), var(--s), var(--l)) calc(var(--space) * 28),
+			hsl(calc(var(--h) * 14), var(--s), var(--l)) calc(var(--space) * 29),
+			black calc(var(--space) * 29.001),
+			black calc(var(--space) * 29.999),
+			hsl(calc(var(--h) * 15), var(--s), var(--l)) calc(var(--space) * 30),
+			hsl(calc(var(--h) * 15), var(--s), var(--l)) calc(var(--space) * 31),
+			black calc(var(--space) * 31.001),
+			black calc(var(--space) * 31.999)
+		),
+		repeating-linear-gradient(
+			90deg,
+			var(--vio),
+			var(--blu),
+			var(--gre),
+			var(--yel),
+			var(--red),
+			var(--vio)
+		),
+		repeating-linear-gradient(
+			90deg,
+			var(--bar-bg) calc(var(--bars) * 2),
+			var(--bar-color) calc(var(--bars) * 3),
+			var(--bar-bg) calc(var(--bars) * 3.5),
+			var(--bar-color) calc(var(--bars) * 4),
+			var(--bar-bg) calc(var(--bars) * 5),
+			var(--bar-bg) calc(var(--bars) * 12)
+		),
+		repeating-linear-gradient(
+			90deg,
+			var(--bar-bg) calc(var(--bars) * 2),
+			var(--bar-color) calc(var(--bars) * 3),
+			var(--bar-bg) calc(var(--bars) * 3.5),
+			var(--bar-color) calc(var(--bars) * 4),
+			var(--bar-bg) calc(var(--bars) * 5),
+			var(--bar-bg) calc(var(--bars) * 9)
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(230, 230, 230, 0.85) 0%,
+			rgba(200, 200, 200, 0.1) 25%,
+			rgb(0, 0, 0) 90%
+		);
 
-  background-image:
-    repeating-linear-gradient( 90deg, 
-      hsl(calc(var(--h)*0), var(--s), var(--l)) calc(var(--space)*0), hsl(calc(var(--h)*0), var(--s), var(--l)) calc(var(--space)*1), 
-      black calc(var(--space)*1.001), black calc(var(--space)*1.999),
-      hsl(calc(var(--h)*1), var(--s), var(--l)) calc(var(--space)*2), hsl(calc(var(--h)*1), var(--s), var(--l)) calc(var(--space)*3), 
-      black calc(var(--space)*3.001), black calc(var(--space)*3.999),
-      hsl(calc(var(--h)*2), var(--s), var(--l)) calc(var(--space)*4), hsl(calc(var(--h)*2), var(--s), var(--l)) calc(var(--space)*5), 
-      black calc(var(--space)*5.001), black calc(var(--space)*5.999),
-      hsl(calc(var(--h)*3), var(--s), var(--l)) calc(var(--space)*6), hsl(calc(var(--h)*3), var(--s), var(--l)) calc(var(--space)*7), 
-      black calc(var(--space)*7.001), black calc(var(--space)*7.999),
-      hsl(calc(var(--h)*4), var(--s), var(--l)) calc(var(--space)*8), hsl(calc(var(--h)*4), var(--s), var(--l)) calc(var(--space)*9), 
-      black calc(var(--space)*9.001), black calc(var(--space)*9.999),
-      hsl(calc(var(--h)*5), var(--s), var(--l)) calc(var(--space)*10), hsl(calc(var(--h)*5), var(--s), var(--l)) calc(var(--space)*11), 
-      black calc(var(--space)*11.001), black calc(var(--space)*11.999),
-      hsl(calc(var(--h)*6), var(--s), var(--l)) calc(var(--space)*12), hsl(calc(var(--h)*6), var(--s), var(--l)) calc(var(--space)*13), 
-      black calc(var(--space)*13.001), black calc(var(--space)*13.999),
-      hsl(calc(var(--h)*7), var(--s), var(--l)) calc(var(--space)*14), hsl(calc(var(--h)*7), var(--s), var(--l)) calc(var(--space)*15), 
-      black calc(var(--space)*15.001), black calc(var(--space)*15.999),
-      hsl(calc(var(--h)*8), var(--s), var(--l)) calc(var(--space)*16), hsl(calc(var(--h)*8), var(--s), var(--l)) calc(var(--space)*17), 
-      black calc(var(--space)*17.001), black calc(var(--space)*17.999),
-      hsl(calc(var(--h)*9), var(--s), var(--l)) calc(var(--space)*18), hsl(calc(var(--h)*9), var(--s), var(--l)) calc(var(--space)*19), 
-      black calc(var(--space)*19.001), black calc(var(--space)*19.999),
-      hsl(calc(var(--h)*10), var(--s), var(--l)) calc(var(--space)*20), hsl(calc(var(--h)*10), var(--s), var(--l)) calc(var(--space)*21), 
-      black calc(var(--space)*21.001), black calc(var(--space)*21.999),
-      hsl(calc(var(--h)*11), var(--s), var(--l)) calc(var(--space)*22), hsl(calc(var(--h)*11), var(--s), var(--l)) calc(var(--space)*23), 
-      black calc(var(--space)*23.001), black calc(var(--space)*23.999),
-      hsl(calc(var(--h)*12), var(--s), var(--l)) calc(var(--space)*24), hsl(calc(var(--h)*12), var(--s), var(--l)) calc(var(--space)*25), 
-      black calc(var(--space)*25.001), black calc(var(--space)*25.999),
-      hsl(calc(var(--h)*13), var(--s), var(--l)) calc(var(--space)*26), hsl(calc(var(--h)*13), var(--s), var(--l)) calc(var(--space)*27), 
-      black calc(var(--space)*27.001), black calc(var(--space)*27.999),
-      hsl(calc(var(--h)*14), var(--s), var(--l)) calc(var(--space)*28), hsl(calc(var(--h)*14), var(--s), var(--l)) calc(var(--space)*29), 
-      black calc(var(--space)*29.001), black calc(var(--space)*29.999),
-      hsl(calc(var(--h)*15), var(--s), var(--l)) calc(var(--space)*30), hsl(calc(var(--h)*15), var(--s), var(--l)) calc(var(--space)*31), 
-      black calc(var(--space)*31.001), black calc(var(--space)*31.999)
-    ),
-    repeating-linear-gradient( 90deg, 
-      var(--vio), var(--blu), var(--gre), var(--yel), var(--red), var(--vio)
-    ),
-    repeating-linear-gradient( 90deg, 
-      var(--bar-bg) calc(var(--bars)*2), var(--bar-color) calc(var(--bars)*3), var(--bar-bg) calc(var(--bars)*3.5), var(--bar-color) calc(var(--bars)*4), var(--bar-bg) calc(var(--bars)*5), var(--bar-bg) calc(var(--bars)*12)
-    ),
-    repeating-linear-gradient( 90deg, 
-      var(--bar-bg) calc(var(--bars)*2), var(--bar-color) calc(var(--bars)*3), var(--bar-bg) calc(var(--bars)*3.5), var(--bar-color) calc(var(--bars)*4), var(--bar-bg) calc(var(--bars)*5), var(--bar-bg) calc(var(--bars)*9)
-    ),
-    radial-gradient(
-      farthest-corner circle 
-        at var(--mx) var(--my), 
-        rgba(230, 230, 230, 0.85) 0%, 
-        rgba(200, 200, 200, .1) 25%, 
-        rgb(0, 0, 0) 90%
-      );
+	background-blend-mode: soft-light, soft-light, screen, overlay;
+	background-position: center, calc(((50% - var(--posx)) * 25) + 50%) center,
+		calc(var(--posx) * -1.2) var(--posy), var(--pos), center;
+	background-size: 100% 100%, 200% 200%, 237% 237%, 195% 195%, 120% 120%;
 
-  background-blend-mode: soft-light, soft-light, screen, overlay;
-  background-position: center, calc(((50% - var(--posx)) * 25) + 50%) center, calc(var(--posx)*-1.2) var(--posy), var(--pos), center;
-  background-size: 100% 100%, 200% 200%, 237% 237%, 195% 195%, 120% 120%;
-
-  filter: brightness(calc((var(--hyp) + 0.7)*0.7)) contrast(3) saturate(.35);
-
+	filter: brightness(calc((var(--hyp) + 0.7) * 0.7)) contrast(3) saturate(0.35);
 }
-
-
-
-
-
-
 
 /*
 
@@ -107,96 +150,89 @@
 
 */
 
-.card[data-rarity="rare holo galaxy"] .card__glare {
-  
-  background-image:
-  radial-gradient( 
-    farthest-corner circle 
-    at var(--mx) var(--my), 
-    rgba(222, 245, 250, 0.7) 10%, 
-    rgba(255, 255, 255, 0.5) 20%, 
-    rgba(0, 0, 0, 0.5) 90% 
-    );
-    
+.card[data-rarity='rare holo galaxy'] .card__glare {
+	background-image: radial-gradient(
+		farthest-corner circle at var(--mx) var(--my),
+		rgba(222, 245, 250, 0.7) 10%,
+		rgba(255, 255, 255, 0.5) 20%,
+		rgba(0, 0, 0, 0.5) 90%
+	);
 }
 
-.card[data-rarity="rare holo"] .card__glare:after,
-.card[data-rarity="rare holo galaxy"] .card__glare:after {
-
-  content: "";
-  clip-path: inset( 10% 8.5% 52.5% 8.5% );
-  background-image: 
-    radial-gradient( 
-      farthest-corner circle 
-      at var(--mx) var(--my), 
-      rgb(229, 239, 255) 5%, 
-      rgba(100, 100, 100, 0.5) 35%, 
-      rgba(0, 0, 0, 0.9) 80% 
-    );
-
+.card[data-rarity='rare holo'] .card__glare:after,
+.card[data-rarity='rare holo galaxy'] .card__glare:after {
+	content: '';
+	clip-path: inset(10% 8.5% 52.5% 8.5%);
+	background-image: radial-gradient(
+		farthest-corner circle at var(--mx) var(--my),
+		rgb(229, 239, 255) 5%,
+		rgba(100, 100, 100, 0.5) 35%,
+		rgba(0, 0, 0, 0.9) 80%
+	);
 }
 
-.card[data-rarity="rare holo galaxy"] .card__shine {
+.card[data-rarity='rare holo galaxy'] .card__shine {
+	--space: 80px;
+	--h: 21;
+	--s: 70%;
+	--l: 50%;
+	--bars: 50px;
+	--bar-color: rgba(255, 255, 255, 0.6);
+	--bar-bg: rgb(10, 10, 10);
 
-  --space: 80px;
-  --h: 21;
-  --s: 70%;
-  --l: 50%;
-  --bars: 50px;
-  --bar-color: rgba(255, 255, 255, 0.6);
-  --bar-bg: rgb(10, 10, 10);
+	clip-path: inset(10% 8.5% 52.5% 8.5%);
 
-  clip-path: inset( 10% 8.5% 52.5% 8.5% );
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
+		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
+		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png'),
+		repeating-linear-gradient(
+			82deg,
+			rgb(218, 56, 50) calc(var(--space) * 1),
+			rgb(219, 204, 86) calc(var(--space) * 2),
+			rgb(121, 199, 58) calc(var(--space) * 3),
+			rgb(58, 192, 183) calc(var(--space) * 4),
+			rgb(71, 98, 207) calc(var(--space) * 5),
+			rgb(170, 69, 209) calc(var(--space) * 6),
+			rgb(218, 56, 50) calc(var(--space) * 10)
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(255, 255, 255, 0.6) 5%,
+			rgba(150, 150, 150, 0.3) 40%,
+			rgb(0, 0, 0) 100%
+		);
 
-  background-image: 
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"),
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"),
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/galaxy.png"), 
-    repeating-linear-gradient(
-      82deg, 
-      rgb(218, 56, 50) calc(var(--space)*1), 
-      rgb(219, 204, 86) calc(var(--space)*2), 
-      rgb(121, 199, 58) calc(var(--space)*3), 
-      rgb(58, 192, 183) calc(var(--space)*4), 
-      rgb(71, 98, 207) calc(var(--space)*5), 
-      rgb(170, 69, 209) calc(var(--space)*6), 
-      rgb(218, 56, 50) calc(var(--space)*10) 
-    ), 
-    radial-gradient( 
-      farthest-corner circle 
-      at var(--mx) var(--my), 
-      rgba(255, 255, 255, 0.6) 5%, 
-      rgba(150, 150, 150, .3) 40%, 
-      rgb(0, 0, 0) 100% 
-  );
+	background-blend-mode: color-dodge, color-burn, saturation, screen;
+	background-position: center, center, center,
+		calc(((50% - var(--posx)) * 2.5) + 50%) calc(((50% - var(--posy)) * 2.5) + 50%), center;
+	background-size: cover, cover, cover, 600% 1200%, cover;
 
-  background-blend-mode: color-dodge, color-burn, saturation, screen;
-  background-position: center, center, center, calc(((50% - var(--posx)) * 2.5) + 50%) calc(((50% - var(--posy)) * 2.5) + 50%), center;
-  background-size: cover, cover, cover, 600% 1200%, cover;
-
-  filter: brightness(.75) contrast(1.2) saturate(1.5);
-  mix-blend-mode: color-dodge;
-
+	filter: brightness(0.75) contrast(1.2) saturate(1.5);
+	mix-blend-mode: color-dodge;
 }
 
-
-
-.card[data-rarity="rare holo"][data-subtypes^="stage"] .card__shine,
-.card[data-rarity="rare holo galaxy"][data-subtypes^="stage"] .card__shine,
-.card[data-rarity="rare holo"][data-subtypes^="stage"] .card__glare:after,
-.card[data-rarity="rare holo galaxy"][data-subtypes^="stage"] .card__glare:after {
-  clip-path: polygon(91.78% 10%, 57% 10%, 53.92% 12.00%, 17% 12%, 16% 14%, 12% 16%, 8.5% 16%, 7.93% 47.41%, 92.07% 47.41%);
+.card[data-rarity='rare holo'][data-subtypes^='stage'] .card__shine,
+.card[data-rarity='rare holo galaxy'][data-subtypes^='stage'] .card__shine,
+.card[data-rarity='rare holo'][data-subtypes^='stage'] .card__glare:after,
+.card[data-rarity='rare holo galaxy'][data-subtypes^='stage'] .card__glare:after {
+	clip-path: polygon(
+		91.78% 10%,
+		57% 10%,
+		53.92% 12%,
+		17% 12%,
+		16% 14%,
+		12% 16%,
+		8.5% 16%,
+		7.93% 47.41%,
+		92.07% 47.41%
+	);
 }
-.card[data-rarity="rare holo"][data-subtypes^="supporter"] .card__shine,
-.card[data-rarity="rare holo galaxy"][data-subtypes^="supporter"] .card__shine,
-.card[data-rarity="rare holo"][data-subtypes^="supporter"] .card__glare:after,
-.card[data-rarity="rare holo galaxy"][data-subtypes^="supporter"] .card__glare:after {
-  clip-path: inset(14.5% 7.9% 48.2% 8.7%);
+.card[data-rarity='rare holo'][data-subtypes^='supporter'] .card__shine,
+.card[data-rarity='rare holo galaxy'][data-subtypes^='supporter'] .card__shine,
+.card[data-rarity='rare holo'][data-subtypes^='supporter'] .card__glare:after,
+.card[data-rarity='rare holo galaxy'][data-subtypes^='supporter'] .card__glare:after {
+	clip-path: inset(14.5% 7.9% 48.2% 8.7%);
 }
-
-
-
-
 
 /*
 
@@ -204,64 +240,56 @@
 
 */
 
-.card[data-rarity*="rare holo v"] .card__shine,
-.card[data-rarity*="rare holo v"] .card__shine:after {
+.card[data-rarity*='rare holo v'] .card__shine,
+.card[data-rarity*='rare holo v'] .card__shine:after {
+	--space: 5%;
+	--angle: 133deg;
+	--imgsize: 500px;
 
-  --space: 5%;
-  --angle: 133deg;
-  --imgsize: 500px;
+	background-image: var(--grain),
+		repeating-linear-gradient(
+			0deg,
+			rgb(255, 119, 115) calc(var(--space) * 1),
+			rgba(255, 237, 95, 1) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgba(120, 148, 255, 1) calc(var(--space) * 5),
+			rgb(216, 117, 255) calc(var(--space) * 6),
+			rgb(255, 119, 115) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			#0e152e 0%,
+			hsl(180, 10%, 60%) 3.8%,
+			hsl(180, 29%, 66%) 4.5%,
+			hsl(180, 10%, 60%) 5.2%,
+			#0e152e 10%,
+			#0e152e 12%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(0, 0, 0, 0.1) 12%,
+			rgba(0, 0, 0, 0.15) 20%,
+			rgba(0, 0, 0, 0.25) 120%
+		);
 
-  background-image:
-    var(--grain),
-    repeating-linear-gradient( 0deg, 
-      rgb(255, 119, 115) calc(var(--space)*1), 
-      rgba(255,237,95,1) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgba(120,148,255,1) calc(var(--space)*5), 
-      rgb(216, 117, 255) calc(var(--space)*6), 
-      rgb(255, 119, 115) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      #0e152e 0%, 
-      hsl(180, 10%, 60%) 3.8%, 
-      hsl(180, 29%, 66%) 4.5%, 
-      hsl(180, 10%, 60%) 5.2%, 
-      #0e152e 10% , 
-      #0e152e 12% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(0, 0, 0, .1) 12%, 
-      rgba(0, 0, 0, .15) 20%, 
-      rgba(0, 0, 0, .25) 120%
-    );
+	background-blend-mode: screen, hue, hard-light;
+	background-size: var(--imgsize), 200% 700%, 300%, 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  background-blend-mode: screen, hue, hard-light;
-  background-size: var(--imgsize), 200% 700%, 300%, 200%;
-  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
-  
-  filter: brightness(.8) contrast(2.95) saturate(.5);
-
+	filter: brightness(0.8) contrast(2.95) saturate(0.5);
 }
 
-.card[data-rarity="rare holo v"] .card__shine:after {
+.card[data-rarity='rare holo v'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
+		var(--posx) var(--posy);
+	background-size: var(--imgsize), 200% 400%, 195%, 200%;
 
-  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
-  background-size: var(--imgsize), 200% 400%, 195%, 200%;
-
-  filter: brightness(1) contrast(2.5) saturate(1.75);
-  mix-blend-mode: soft-light;
-
+	filter: brightness(1) contrast(2.5) saturate(1.75);
+	mix-blend-mode: soft-light;
 }
-
-
-
-
 
 /*
 
@@ -269,53 +297,43 @@
 
 */
 
-.card[data-rarity="rare holo vmax"] .card__shine {
-  --space: 6%;
-  --angle: 133deg;
-  --imgsize: 60% 30%;
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/vmaxbg.webp"),
-    repeating-linear-gradient( -33deg, 
-      rgb(206, 42, 36) calc(var(--space)*1),  
-      rgb(157, 170, 223) calc(var(--space)*2), 
-      rgb(45, 153, 146) calc(var(--space)*3), 
-      rgb(29, 151, 36) calc(var(--space)*4), 
-      rgb(181, 64, 228) calc(var(--space)*5), 
-      rgb(206, 42, 36) calc(var(--space)*6)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      rgba(14, 21, 46, 0.5) 0%, 
-      hsl(180, 10%, 50%) 2.5%, 
-      hsl(83, 50%, 35%) 5%, 
-      hsl(180, 10%, 50%) 7.5%, 
-      rgba(14, 21, 46, 0.5) 10% , 
-      rgba(14, 21, 46, 0.5) 15% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(6, 218, 255, 0.6) 0%, 
-      rgba(38, 235, 127, 0.6) 25%, 
-      rgba(155, 78, 228, 0.6) 50%, 
-      rgba(228, 78, 90, 0.6) 75%
-    );
+.card[data-rarity='rare holo vmax'] .card__shine {
+	--space: 6%;
+	--angle: 133deg;
+	--imgsize: 60% 30%;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/vmaxbg.webp'),
+		repeating-linear-gradient(
+			-33deg,
+			rgb(206, 42, 36) calc(var(--space) * 1),
+			rgb(157, 170, 223) calc(var(--space) * 2),
+			rgb(45, 153, 146) calc(var(--space) * 3),
+			rgb(29, 151, 36) calc(var(--space) * 4),
+			rgb(181, 64, 228) calc(var(--space) * 5),
+			rgb(206, 42, 36) calc(var(--space) * 6)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			rgba(14, 21, 46, 0.5) 0%,
+			hsl(180, 10%, 50%) 2.5%,
+			hsl(83, 50%, 35%) 5%,
+			hsl(180, 10%, 50%) 7.5%,
+			rgba(14, 21, 46, 0.5) 10%,
+			rgba(14, 21, 46, 0.5) 15%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(6, 218, 255, 0.6) 0%,
+			rgba(38, 235, 127, 0.6) 25%,
+			rgba(155, 78, 228, 0.6) 50%,
+			rgba(228, 78, 90, 0.6) 75%
+		);
 
-  background-blend-mode: color-burn, screen, soft-light;
-  background-size: var(--imgsize), 1100% 1100%, 600% 600%, 200% 200%;
-  background-position: 
-    center, 
-    0% var(--posy), 
-    var(--posx) var(--posy), 
-    var(--posx) var(--posy);
+	background-blend-mode: color-burn, screen, soft-light;
+	background-size: var(--imgsize), 1100% 1100%, 600% 600%, 200% 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  filter: brightness(calc((var(--hyp)*0.3) + 0.5)) contrast(2.5) saturate(.6);
-
+	filter: brightness(calc((var(--hyp) * 0.3) + 0.5)) contrast(2.5) saturate(0.6);
 }
-
-
-
-
 
 /*
 
@@ -323,64 +341,56 @@
 
 */
 
-.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine,
-.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine:after {
+.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine,
+.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine:after {
+	--space: 5%;
+	--angle: 133deg;
+	--imgsize: 30%;
 
-  --space: 5%;
-  --angle: 133deg;
-  --imgsize: 30%;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/ancient.webp'),
+		repeating-linear-gradient(
+			0deg,
+			rgb(255, 119, 115) calc(var(--space) * 1),
+			rgba(255, 237, 95, 1) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgba(120, 148, 255, 1) calc(var(--space) * 5),
+			rgb(216, 117, 255) calc(var(--space) * 6),
+			rgb(255, 119, 115) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			#0e152e 0%,
+			hsl(180, 10%, 60%) 3.8%,
+			hsl(180, 29%, 66%) 4.5%,
+			hsl(180, 10%, 60%) 5.2%,
+			#0e152e 10%,
+			#0e152e 12%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(0, 0, 0, 0.1) 12%,
+			rgba(0, 0, 0, 0.15) 20%,
+			rgba(0, 0, 0, 0.25) 120%
+		);
 
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/ancient.webp"),
-    repeating-linear-gradient( 0deg, 
-      rgb(255, 119, 115) calc(var(--space)*1), 
-      rgba(255,237,95,1) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgba(120,148,255,1) calc(var(--space)*5), 
-      rgb(216, 117, 255) calc(var(--space)*6), 
-      rgb(255, 119, 115) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      #0e152e 0%, 
-      hsl(180, 10%, 60%) 3.8%, 
-      hsl(180, 29%, 66%) 4.5%, 
-      hsl(180, 10%, 60%) 5.2%, 
-      #0e152e 10% , 
-      #0e152e 12% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(0, 0, 0, .1) 12%, 
-      rgba(0, 0, 0, .15) 20%, 
-      rgba(0, 0, 0, .25) 120%
-    );
+	background-blend-mode: soft-light, hue, hard-light;
+	background-size: var(--imgsize), 200% 700%, 300%, 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  background-blend-mode: soft-light, hue, hard-light;
-  background-size: var(--imgsize), 200% 700%, 300%, 200%;
-  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
-  
-  filter: brightness(.8) contrast(2) saturate(.75);
-
+	filter: brightness(0.8) contrast(2) saturate(0.75);
 }
 
-.card[data-rarity="rare holo vstar"][data-supertype="pokémon"] .card__shine:after {
+.card[data-rarity='rare holo vstar'][data-supertype='pokémon'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-size: var(--imgsize), 200% 400%, 195%, 200%;
+	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
+		var(--posx) var(--posy);
 
-  background-size: var(--imgsize), 200% 400%, 195%, 200%;
-  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
-
-  filter: brightness(1.2) contrast(1.5) saturate(1.75);
-  mix-blend-mode: exclusion;
-
+	filter: brightness(1.2) contrast(1.5) saturate(1.75);
+	mix-blend-mode: exclusion;
 }
-
-
-
-
 
 /*
 
@@ -388,64 +398,56 @@
 
 */
 
-.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine,
-.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine:after {
+.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine,
+.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine:after {
+	--space: 5%;
+	--angle: 133deg;
+	--imgsize: 50%;
 
-  --space: 5%;
-  --angle: 133deg;
-  --imgsize: 50%;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp'),
+		repeating-linear-gradient(
+			0deg,
+			rgb(255, 119, 115) calc(var(--space) * 1),
+			rgba(255, 237, 95, 1) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgba(120, 148, 255, 1) calc(var(--space) * 5),
+			rgb(216, 117, 255) calc(var(--space) * 6),
+			rgb(255, 119, 115) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			#0e152e 0%,
+			hsl(180, 10%, 60%) 3.8%,
+			hsl(180, 29%, 66%) 4.5%,
+			hsl(180, 10%, 60%) 5.2%,
+			#0e152e 10%,
+			#0e152e 12%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(0, 0, 0, 0.1) 12%,
+			rgba(0, 0, 0, 0.15) 20%,
+			rgba(0, 0, 0, 0.25) 120%
+		);
 
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp"),
-    repeating-linear-gradient( 0deg, 
-      rgb(255, 119, 115) calc(var(--space)*1), 
-      rgba(255,237,95,1) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgba(120,148,255,1) calc(var(--space)*5), 
-      rgb(216, 117, 255) calc(var(--space)*6), 
-      rgb(255, 119, 115) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      #0e152e 0%, 
-      hsl(180, 10%, 60%) 3.8%, 
-      hsl(180, 29%, 66%) 4.5%, 
-      hsl(180, 10%, 60%) 5.2%, 
-      #0e152e 10% , 
-      #0e152e 12% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(0, 0, 0, .1) 12%, 
-      rgba(0, 0, 0, .15) 20%, 
-      rgba(0, 0, 0, .25) 120%
-    );
+	background-blend-mode: exclusion, hue, hard-light;
+	background-size: var(--imgsize), 200% 700%, 300%, 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  background-blend-mode: exclusion, hue, hard-light;
-  background-size: var(--imgsize), 200% 700%, 300%, 200%;
-  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
-
-  filter: brightness(calc((var(--hyp)*0.3) + 0.5)) contrast(2) saturate(1.5);
-
+	filter: brightness(calc((var(--hyp) * 0.3) + 0.5)) contrast(2) saturate(1.5);
 }
 
-.card[data-rarity="rare ultra"][data-supertype="pokémon"] .card__shine:after {
+.card[data-rarity='rare ultra'][data-supertype='pokémon'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-size: var(--imgsize), 200% 400%, 195%, 200%;
+	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
+		var(--posx) var(--posy);
 
-  background-size: var(--imgsize), 200% 400%, 195%, 200%;
-  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
-
-  filter: brightness(calc((var(--hyp)*0.5) + .8)) contrast(1.6) saturate(1.4);
-  mix-blend-mode: exclusion;
-
+	filter: brightness(calc((var(--hyp) * 0.5) + 0.8)) contrast(1.6) saturate(1.4);
+	mix-blend-mode: exclusion;
 }
-
-
-
-
 
 /*
 
@@ -453,64 +455,56 @@
 
 */
 
-.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine,
-.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine:after {
+.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine,
+.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine:after {
+	--space: 5%;
+	--angle: 133deg;
+	--imgsize: 50%;
 
-  --space: 5%;
-  --angle: 133deg;
-  --imgsize: 50%;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/trainerbg.jpg'),
+		repeating-linear-gradient(
+			0deg,
+			rgb(255, 119, 115) calc(var(--space) * 1),
+			rgba(255, 237, 95, 1) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgba(120, 148, 255, 1) calc(var(--space) * 5),
+			rgb(216, 117, 255) calc(var(--space) * 6),
+			rgb(255, 119, 115) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			#0e152e 0%,
+			hsl(180, 10%, 60%) 3.8%,
+			hsl(180, 29%, 66%) 4.5%,
+			hsl(180, 10%, 60%) 5.2%,
+			#0e152e 10%,
+			#0e152e 12%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(0, 0, 0, 0.1) 12%,
+			rgba(0, 0, 0, 0.15) 20%,
+			rgba(0, 0, 0, 0.25) 120%
+		);
 
-  background-image:
-  url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/trainerbg.jpg"),
-    repeating-linear-gradient( 0deg, 
-      rgb(255, 119, 115) calc(var(--space)*1), 
-      rgba(255,237,95,1) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgba(120,148,255,1) calc(var(--space)*5), 
-      rgb(216, 117, 255) calc(var(--space)*6), 
-      rgb(255, 119, 115) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      #0e152e 0%, 
-      hsl(180, 10%, 60%) 3.8%, 
-      hsl(180, 29%, 66%) 4.5%, 
-      hsl(180, 10%, 60%) 5.2%, 
-      #0e152e 10% , 
-      #0e152e 12% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(0, 0, 0, .1) 12%, 
-      rgba(0, 0, 0, .15) 20%, 
-      rgba(0, 0, 0, .25) 120%
-    );
+	background-blend-mode: difference, hue, hard-light;
+	background-size: var(--imgsize), 200% 700%, 300%, 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  background-blend-mode: difference, hue, hard-light;
-  background-size: var(--imgsize), 200% 700%, 300%, 200%;
-  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
-
-  filter: brightness(0.75) contrast(2.5) saturate(.75);
-  
+	filter: brightness(0.75) contrast(2.5) saturate(0.75);
 }
 
-.card[data-rarity="rare ultra"][data-subtypes*="supporter"] .card__shine:after {
+.card[data-rarity='rare ultra'][data-subtypes*='supporter'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-size: var(--imgsize), 200% 400%, 195%, 200%;
+	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
+		var(--posx) var(--posy);
 
-  background-size: var(--imgsize), 200% 400%, 195%, 200%;
-  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
-
-  filter: brightness(1.2) contrast(1) saturate(1.75);
-  mix-blend-mode: exclusion;
-
+	filter: brightness(1.2) contrast(1) saturate(1.75);
+	mix-blend-mode: exclusion;
 }
-
-
-
-
 
 /*
 
@@ -518,52 +512,49 @@
 
 */
 
-.card[data-rarity^="rare rainbow"] .card__shine,
-.card[data-rarity^="rare rainbow"] .card__shine:after {
+.card[data-rarity^='rare rainbow'] .card__shine,
+.card[data-rarity^='rare rainbow'] .card__shine:after {
+	--space: 7%;
+	--angle: -20deg;
+	--angle2: 130deg;
+	--imgsize: 540px 700px;
 
-  --space: 7%;
-  --angle: -20deg;
-  --angle2: 130deg;
-  --imgsize: 540px 700px;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
+		repeating-linear-gradient(
+			var(--angle),
+			rgb(253, 71, 65) calc(var(--space) * 1),
+			rgb(255, 243, 151) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgb(75, 198, 255) calc(var(--space) * 5),
+			rgb(255, 73, 246) calc(var(--space) * 6),
+			rgb(255, 56, 49) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle2),
+			rgba(89, 46, 80, 0.5) 0%,
+			hsl(118, 43%, 76%) 2.5%,
+			rgb(223, 96, 202) 5%,
+			hsl(180, 57%, 56%) 7.5%,
+			rgba(14, 21, 46, 0.5) 10%,
+			rgba(14, 21, 46, 0.5) 15%
+		),
+		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion2.webp');
 
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
-    repeating-linear-gradient( var(--angle), 
-      rgb(253, 71, 65) calc(var(--space)*1), 
-      rgb(255, 243, 151) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgb(75, 198, 255) calc(var(--space)*5), 
-      rgb(255, 73, 246) calc(var(--space)*6), 
-      rgb(255, 56, 49) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( var(--angle2), 
-      rgba(89, 46, 80, 0.5) 0%, 
-      hsl(118, 43%, 76%) 2.5%, 
-      rgb(223, 96, 202) 5%, 
-      hsl(180, 57%, 56%) 7.5%, 
-      rgba(14, 21, 46, 0.5) 10% , 
-      rgba(14, 21, 46, 0.5) 15% 
-    ),
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion2.webp");
+	background-size: 50% 50%, 500% 500%, 1000% 1000%, var(--imgsize);
+	background-position: center, 0% calc(var(--posy) * 1.5), var(--posx) var(--posy), center;
+	background-blend-mode: color-burn, soft-light, normal;
 
-  background-size: 50% 50%, 500% 500%, 1000% 1000%, var(--imgsize);
-  background-position: center, 0% calc( var(--posy) * 1.5 ), var(--posx) var(--posy), center;
-  background-blend-mode: color-burn, soft-light, normal;
-
-  filter: brightness(calc((var(--hyp)*0.25) + 0.66)) contrast(2) saturate(.95);
-
+	filter: brightness(calc((var(--hyp) * 0.25) + 0.66)) contrast(2) saturate(0.95);
 }
 
-.card[data-rarity^="rare rainbow"] .card__shine:after {
+.card[data-rarity^='rare rainbow'] .card__shine:after {
+	content: '';
 
-  content: "";
-
-  background-position: center, 0% calc( var(--posy) * -1 ), calc( var(--posx) * -1 ) calc( var(--posy) * -1 ), center;
-  mix-blend-mode: exclusion;
-
+	background-position: center, 0% calc(var(--posy) * -1),
+		calc(var(--posx) * -1) calc(var(--posy) * -1), center;
+	mix-blend-mode: exclusion;
 }
-
 
 /*
 
@@ -571,15 +562,10 @@
 
 */
 
-.card[data-rarity="rare rainbow alt"] .card__shine,
-.card[data-rarity="rare rainbow alt"] .card__shine:after {
-
-  filter: brightness(calc((var(--hyp)*0.25) + 0.66)) contrast(3) saturate(.7);
-
+.card[data-rarity='rare rainbow alt'] .card__shine,
+.card[data-rarity='rare rainbow alt'] .card__shine:after {
+	filter: brightness(calc((var(--hyp) * 0.25) + 0.66)) contrast(3) saturate(0.7);
 }
-
-
-
 
 /*
 
@@ -587,58 +573,49 @@
 
 */
 
-.card[data-rarity="rare secret"] .card__shine,
-.card[data-rarity="rare secret"] .card__shine:after {
+.card[data-rarity='rare secret'] .card__shine,
+.card[data-rarity='rare secret'] .card__shine:after {
+	--angle: 110deg;
+	--imgsize: 250px;
 
-  --angle: 110deg;
-  --imgsize: 250px;
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
+		repeating-linear-gradient(
+			var(--angle),
+			rgba(89, 46, 80, 0.5) 0%,
+			hsl(39, 37%, 60%) 2.5%,
+			rgb(216, 183, 92) 5%,
+			hsl(39, 37%, 60%) 7.5%,
+			rgba(14, 21, 46, 0.5) 10%,
+			rgba(14, 21, 46, 0.5) 15%
+		),
+		url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/metal.webp');
 
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
-    repeating-linear-gradient( var(--angle), 
-      rgba(89, 46, 80, 0.5) 0%, 
-      hsl(39, 37%, 60%) 2.5%, 
-      rgb(216, 183, 92) 5%, 
-      hsl(39, 37%, 60%) 7.5%, 
-      rgba(14, 21, 46, 0.5) 10% , 
-      rgba(14, 21, 46, 0.5) 15% 
-    ), 
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/metal.webp");
+	background-size: 50% 50%, 600% 600%, var(--imgsize);
+	background-position: center, var(--posx) var(--posy), center;
+	background-blend-mode: color-burn, darken;
 
-  background-size: 50% 50%, 600% 600%, var(--imgsize);
-  background-position: center, var(--posx) var(--posy), center;
-  background-blend-mode: color-burn, darken;
-
-  filter: brightness(calc((var(--hyp)*0.4) + 0.7)) contrast(3) saturate(.66);
-
-
+	filter: brightness(calc((var(--hyp) * 0.4) + 0.7)) contrast(3) saturate(0.66);
 }
 
-.card[data-rarity="rare secret"] .card__shine:after {
+.card[data-rarity='rare secret'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
+		repeating-linear-gradient(
+			var(--angle),
+			rgba(89, 46, 80, 0.5) 0%,
+			hsl(39, 37%, 60%) 2.5%,
+			rgb(216, 183, 92) 5%,
+			hsl(39, 37%, 60%) 7.5%,
+			rgba(14, 21, 46, 0.5) 10%,
+			rgba(14, 21, 46, 0.5) 15%
+		);
 
-  background-image:
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"),
-    repeating-linear-gradient( var(--angle), 
-      rgba(89, 46, 80, 0.5) 0%, 
-      hsl(39, 37%, 60%) 2.5%, 
-      rgb(216, 183, 92) 5%, 
-      hsl(39, 37%, 60%) 7.5%, 
-      rgba(14, 21, 46, 0.5) 10% , 
-      rgba(14, 21, 46, 0.5) 15% 
-    );
+	background-position: center, calc(var(--posx) * -1) calc(var(--posy) * -1), center;
 
-  background-position: center, calc( var(--posx) * -1 ) calc( var(--posy) * -1 ), center;
-
-  filter: brightness(calc((var(--hyp)*0.3) + 0.7)) contrast(2.5) saturate(.66);
-  mix-blend-mode: exclusion;
-
+	filter: brightness(calc((var(--hyp) * 0.3) + 0.7)) contrast(2.5) saturate(0.66);
+	mix-blend-mode: exclusion;
 }
-
-
-
-
 
 /*
 
@@ -646,137 +623,126 @@
 
 */
 
-.card[data-rarity*="radiant"] .card__shine {
+.card[data-rarity*='radiant'] .card__shine {
+	--barwidth: 1.2%;
+	--space: 200px;
 
-  --barwidth: 1.2%;
-  --space: 200px;
+	opacity: calc(((var(--hyp) * 0.7) + 0.2) * var(--o)) !important;
+	clip-path: inset(2.8% 4% round 2.55% / 1.5%);
 
-  opacity: calc( ((var(--hyp)*0.7) + 0.2) * var(--o) ) !important;
-  clip-path: inset(2.8% 4% round 2.55% / 1.5%);
+	background-image: repeating-linear-gradient(
+			55deg,
+			rgb(255, 161, 158) calc(var(--space) * 1),
+			rgb(85, 178, 255) calc(var(--space) * 2),
+			rgb(255, 199, 146) calc(var(--space) * 3),
+			rgb(130, 255, 213) calc(var(--space) * 4),
+			rgb(253, 170, 240) calc(var(--space) * 5),
+			rgb(148, 241, 255) calc(var(--space) * 6),
+			rgb(255, 161, 158) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			45deg,
+			hsl(0, 0%, 10%) 0%,
+			hsl(0, 0%, 10%) 1%,
+			hsl(0, 0%, 10%) var(--barwidth),
+			hsl(0, 0%, 20%) calc(var(--barwidth) + 0.01%),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 2),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 2 + 0.01%),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 3),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 3 + 0.01%),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 4),
+			hsl(0, 0%, 50%) calc(var(--barwidth) * 4 + 0.01%),
+			hsl(0, 0%, 50%) calc(var(--barwidth) * 5),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 5 + 0.01%),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 6),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 6 + 0.01%),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 7),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 7 + 0.01%),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 8),
+			hsl(0, 0%, 10%) calc(var(--barwidth) * 8 + 0.01%),
+			hsl(0, 0%, 10%) calc(var(--barwidth) * 9),
+			hsl(0, 0%, 0%) calc(var(--barwidth) * 9 + 0.01%),
+			hsl(0, 0%, 0%) calc(var(--barwidth) * 10)
+		),
+		repeating-linear-gradient(
+			-45deg,
+			hsl(0, 0%, 10%) 0%,
+			hsl(0, 0%, 10%) 1%,
+			hsl(0, 0%, 10%) var(--barwidth),
+			hsl(0, 0%, 20%) calc(var(--barwidth) + 0.01%),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 2),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 2 + 0.01%),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 3),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 3 + 0.01%),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 4),
+			hsl(0, 0%, 50%) calc(var(--barwidth) * 4 + 0.01%),
+			hsl(0, 0%, 50%) calc(var(--barwidth) * 5),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 5 + 0.01%),
+			hsl(0, 0%, 42.5%) calc(var(--barwidth) * 6),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 6 + 0.01%),
+			hsl(0, 0%, 35%) calc(var(--barwidth) * 7),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 7 + 0.01%),
+			hsl(0, 0%, 20%) calc(var(--barwidth) * 8),
+			hsl(0, 0%, 10%) calc(var(--barwidth) * 8 + 0.01%),
+			hsl(0, 0%, 10%) calc(var(--barwidth) * 9),
+			hsl(0, 0%, 0%) calc(var(--barwidth) * 9 + 0.01%),
+			hsl(0, 0%, 0%) calc(var(--barwidth) * 10)
+		);
 
-  background-image: 
-    repeating-linear-gradient( 55deg, 
-      rgb(255, 161, 158) calc(var(--space)*1), 
-      rgb(85, 178, 255) calc(var(--space)*2), 
-      rgb(255, 199, 146) calc(var(--space)*3), 
-      rgb(130, 255, 213) calc(var(--space)*4), 
-      rgb(253, 170, 240) calc(var(--space)*5), 
-      rgb(148, 241, 255) calc(var(--space)*6), 
-      rgb(255, 161, 158) calc(var(--space)*7) 
-    ),
-    repeating-linear-gradient( 
-      45deg, 
-      hsl(0,0%,10%) 0% ,  
-      hsl(0,0%,10%) 1% , 
-      hsl(0,0%,10%) var(--barwidth),
-      hsl(0,0%,20%) calc( var(--barwidth) + 0.01% ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 2 ),
-      hsl(0,0%,35%) calc( var(--barwidth) * 2 + 0.01% ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 3 ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 3 + 0.01% ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 4 ) ,
-      hsl(0,0%,50%) calc( var(--barwidth) * 4 + 0.01% ) ,
-      hsl(0,0%,50%) calc( var(--barwidth) * 5 ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 5 + 0.01% ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 6 ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 6 + 0.01% ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 7 ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 7 + 0.01% ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 8 )  ,
-      hsl(0,0%,10%) calc( var(--barwidth) * 8 + 0.01% ) ,
-      hsl(0,0%,10%) calc( var(--barwidth) * 9 )  ,
-      hsl(0,0%,0%) calc( var(--barwidth) * 9 + 0.01% ) ,
-      hsl(0,0%,0%) calc( var(--barwidth) * 10 ) 
-    ),
-    repeating-linear-gradient( 
-      -45deg, 
-      hsl(0,0%,10%) 0% ,  
-      hsl(0,0%,10%) 1% , 
-      hsl(0,0%,10%) var(--barwidth),
-      hsl(0,0%,20%) calc( var(--barwidth) + 0.01% ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 2 ),
-      hsl(0,0%,35%) calc( var(--barwidth) * 2 + 0.01% ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 3 ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 3 + 0.01% ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 4 ) ,
-      hsl(0,0%,50%) calc( var(--barwidth) * 4 + 0.01% ) ,
-      hsl(0,0%,50%) calc( var(--barwidth) * 5 ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 5 + 0.01% ) ,
-      hsl(0,0%,42.5%) calc( var(--barwidth) * 6 ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 6 + 0.01% ) ,
-      hsl(0,0%,35%) calc( var(--barwidth) * 7 ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 7 + 0.01% ) ,
-      hsl(0,0%,20%) calc( var(--barwidth) * 8 )  ,
-      hsl(0,0%,10%) calc( var(--barwidth) * 8 + 0.01% ) ,
-      hsl(0,0%,10%) calc( var(--barwidth) * 9 )  ,
-      hsl(0,0%,0%) calc( var(--barwidth) * 9 + 0.01% ) ,
-      hsl(0,0%,0%) calc( var(--barwidth) * 10 ) 
-    );
+	background-size: 400% 400%, 210% 210%, 210% 210%;
+	background-position: calc(((var(--posx) - 50%) * -2.5) + 50%)
+			calc(((var(--posy) - 50%) * -2.5) + 50%),
+		calc(((var(--posx) - 50%) * 1.5) + 50%) calc(((var(--posy) - 50%) * 1.5) + 50%),
+		calc(((var(--posx) - 50%) * 1.5) + 50%) calc(((var(--posy) - 50%) * 1.5) + 50%);
 
-  background-size: 400% 400%, 210% 210%, 210% 210%;
-  background-position: 
-    calc( ((var(--posx) - 50%) * -2.5) + 50% ) calc( ((var(--posy) - 50%) * -2.5) + 50% ), 
-    calc( ((var(--posx) - 50%) * 1.5) + 50% ) calc( ((var(--posy) - 50%) * 1.5) + 50% ), 
-    calc( ((var(--posx) - 50%) * 1.5) + 50% ) calc( ((var(--posy) - 50%) * 1.5) + 50% );
+	background-blend-mode: exclusion, darken, color-dodge;
 
-  background-blend-mode: exclusion, darken, color-dodge;
-
-  filter: brightness(.95) contrast(4) saturate(0.75);
-  mix-blend-mode: color-dodge;
-
+	filter: brightness(0.95) contrast(4) saturate(0.75);
+	mix-blend-mode: color-dodge;
 }
 
-.card[data-rarity*="radiant"] .card__shine:after {
+.card[data-rarity*='radiant'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-image: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg'),
+		repeating-linear-gradient(
+			55deg,
+			rgb(255, 161, 158) calc(var(--space) * 1),
+			rgb(85, 178, 255) calc(var(--space) * 2),
+			rgb(255, 199, 146) calc(var(--space) * 3),
+			rgb(130, 255, 213) calc(var(--space) * 4),
+			rgb(253, 170, 240) calc(var(--space) * 5),
+			rgb(148, 241, 255) calc(var(--space) * 6),
+			rgb(255, 161, 158) calc(var(--space) * 7)
+		);
 
-  background-image: 
-    url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/rainbow2.jpg"), 
-    repeating-linear-gradient( 55deg, 
-    rgb(255, 161, 158) calc(var(--space)*1), 
-    rgb(85, 178, 255) calc(var(--space)*2), 
-    rgb(255, 199, 146) calc(var(--space)*3), 
-    rgb(130, 255, 213) calc(var(--space)*4), 
-    rgb(253, 170, 240) calc(var(--space)*5), 
-    rgb(148, 241, 255) calc(var(--space)*6), 
-    rgb(255, 161, 158) calc(var(--space)*7) 
-  );
+	background-size: 40%, 400%;
+	background-position: center,
+		calc(((var(--posx) - 50%) * -2.5) + 50%) calc(((var(--posy) - 50%) * -2.5) + 50%);
 
-  background-size: 40%, 400%;
-  background-position: center, calc( ((var(--posx) - 50%) * -2.5) + 50% ) calc( ((var(--posy) - 50%) * -2.5) + 50% );
-  
-  filter: brightness(1) contrast(1) saturate(0);
-  mix-blend-mode: soft-light;
+	filter: brightness(1) contrast(1) saturate(0);
+	mix-blend-mode: soft-light;
 
-  background-blend-mode: multiply;
-  
+	background-blend-mode: multiply;
 }
 
-.card[data-rarity*="radiant"] .card__shine:before {
-  
-  content: "";
-  z-index: 3;
-  grid-area: 1/1;
+.card[data-rarity*='radiant'] .card__shine:before {
+	content: '';
+	z-index: 3;
+	grid-area: 1/1;
 
-  background-image:
-    radial-gradient(
-      farthest-corner ellipse 
-      at calc( ((var(--mx)) * 0.5) + 25% ) calc( ((var(--my)) * 0.5) + 25% ),
-      rgba(100, 100, 100, .5) 5%, 
-      rgba(50, 50, 50, .4) 15%, 
-      rgba(0, 0, 0, .6) 30%
-    );
+	background-image: radial-gradient(
+		farthest-corner ellipse at calc(((var(--mx)) * 0.5) + 25%) calc(((var(--my)) * 0.5) + 25%),
+		rgba(100, 100, 100, 0.5) 5%,
+		rgba(50, 50, 50, 0.4) 15%,
+		rgba(0, 0, 0, 0.6) 30%
+	);
 
-  background-position: center;
-  background-size: 350% 350%;
+	background-position: center;
+	background-size: 350% 350%;
 
-  mix-blend-mode: multiply;
-
+	mix-blend-mode: multiply;
 }
-
-
-
-
 
 /*
 
@@ -784,57 +750,47 @@
 
 */
 
-.card[data-rarity="rare holo"][data-gallery="true"] .card__shine {
+.card[data-rarity='rare holo'][data-gallery='true'] .card__shine {
+	--space: 5%;
+	--angle: -22deg;
+	--imgsize: 200% 400%;
 
-  --space: 5%;
-  --angle: -22deg;
-  --imgsize: 200% 400%;
+	clip-path: inset(2.8% 4% round 2.55% / 1.5%);
 
-  clip-path: inset(2.8% 4% round 2.55% / 1.5%);
+	background-image: repeating-linear-gradient(
+		var(--angle),
+		rgba(174, 102, 202, 0.75) calc(var(--space) * 1),
+		rgba(228, 77, 72, 0.75) calc(var(--space) * 2),
+		rgba(216, 197, 55, 0.75) calc(var(--space) * 3),
+		rgba(124, 201, 62, 0.75) calc(var(--space) * 4),
+		rgba(80, 177, 170, 0.75) calc(var(--space) * 5),
+		rgba(136, 160, 255, 0.75) calc(var(--space) * 6),
+		rgba(176, 105, 204, 0.75) calc(var(--space) * 7)
+	);
 
-  background-image:
-    repeating-linear-gradient( var(--angle),  
-      rgba(174, 102, 202, 0.75) calc(var(--space)*1),
-      rgba(228, 77, 72, 0.75) calc(var(--space)*2), 
-      rgba(216, 197, 55, 0.75) calc(var(--space)*3),  
-      rgba(124, 201, 62, 0.75) calc(var(--space)*4),  
-      rgba(80, 177, 170, 0.75) calc(var(--space)*5),  
-      rgba(136, 160, 255, 0.75) calc(var(--space)*6), 
-      rgba(176, 105, 204, 0.75) calc(var(--space)*7)
-    );
-    
-    background-blend-mode: color-dodge;
-    background-size: var(--imgsize), 300%, 200%;
-    background-position: 0% calc(var(--posy) * 1), var(--posx) var(--posy);
-    
-    filter: brightness(calc((var(--hyp)*0.3) + 0.6)) contrast(2.3) saturate(1.1);
+	background-blend-mode: color-dodge;
+	background-size: var(--imgsize), 300%, 200%;
+	background-position: 0% calc(var(--posy) * 1), var(--posx) var(--posy);
 
+	filter: brightness(calc((var(--hyp) * 0.3) + 0.6)) contrast(2.3) saturate(1.1);
 }
 
-.card[data-rarity="rare holo"][data-gallery="true"] .card__shine:after {
-  
-  content: "";
+.card[data-rarity='rare holo'][data-gallery='true'] .card__shine:after {
+	content: '';
 
-  background-image: 
-    radial-gradient( 
-      farthest-corner ellipse 
-      at calc( ((var(--mx)) * 0.5) + 25% ) calc( ((var(--my)) * 0.5) + 25% ), 
-      rgb(255, 255, 255) 5%, 
-      rgba(55, 0, 55, .6) 25%, 
-      rgb(55, 55, 55) 90% 
-    );
+	background-image: radial-gradient(
+		farthest-corner ellipse at calc(((var(--mx)) * 0.5) + 25%) calc(((var(--my)) * 0.5) + 25%),
+		rgb(255, 255, 255) 5%,
+		rgba(55, 0, 55, 0.6) 25%,
+		rgb(55, 55, 55) 90%
+	);
 
-  background-position: center;
-  background-size: 200% 200%;
+	background-position: center;
+	background-size: 200% 200%;
 
-  filter: brightness(calc((var(--hyp)*0.2) + 0.4)) contrast(.85) saturate(1.1);
-  mix-blend-mode: hard-light;
-
+	filter: brightness(calc((var(--hyp) * 0.2) + 0.4)) contrast(0.85) saturate(1.1);
+	mix-blend-mode: hard-light;
 }
-
-
-
-
 
 /*
 
@@ -842,67 +798,60 @@
 
 */
 
-.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine,
-.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine:after {
+.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine,
+.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine:after {
+	--space: 5%;
+	--angle: 133deg;
+	--img: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp');
+	--imgsize: 60%;
 
-  --space: 5%;
-  --angle: 133deg;
-  --img: url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/illusion.webp");
-  --imgsize: 60%;
+	background-image: var(--img),
+		repeating-linear-gradient(
+			0deg,
+			rgb(255, 119, 115) calc(var(--space) * 1),
+			rgba(255, 237, 95, 1) calc(var(--space) * 2),
+			rgba(168, 255, 95, 1) calc(var(--space) * 3),
+			rgba(131, 255, 247, 1) calc(var(--space) * 4),
+			rgba(120, 148, 255, 1) calc(var(--space) * 5),
+			rgb(216, 117, 255) calc(var(--space) * 6),
+			rgb(255, 119, 115) calc(var(--space) * 7)
+		),
+		repeating-linear-gradient(
+			var(--angle),
+			#0e152e 0%,
+			hsl(180, 10%, 60%) 3.8%,
+			hsl(180, 29%, 66%) 4.5%,
+			hsl(180, 10%, 60%) 5.2%,
+			#0e152e 10%,
+			#0e152e 12%
+		),
+		radial-gradient(
+			farthest-corner circle at var(--mx) var(--my),
+			rgba(0, 0, 0, 0.1) 12%,
+			rgba(0, 0, 0, 0.15) 20%,
+			rgba(0, 0, 0, 0.25) 120%
+		);
 
-  background-image:
-    var(--img),
-    repeating-linear-gradient( 0deg, 
-      rgb(255, 119, 115) calc(var(--space)*1), 
-      rgba(255,237,95,1) calc(var(--space)*2), 
-      rgba(168,255,95,1) calc(var(--space)*3), 
-      rgba(131,255,247,1) calc(var(--space)*4), 
-      rgba(120,148,255,1) calc(var(--space)*5), 
-      rgb(216, 117, 255) calc(var(--space)*6), 
-      rgb(255, 119, 115) calc(var(--space)*7)
-    ),
-    repeating-linear-gradient( 
-      var(--angle), 
-      #0e152e 0%, 
-      hsl(180, 10%, 60%) 3.8%, 
-      hsl(180, 29%, 66%) 4.5%, 
-      hsl(180, 10%, 60%) 5.2%, 
-      #0e152e 10% , 
-      #0e152e 12% 
-      ),
-    radial-gradient(
-      farthest-corner circle 
-      at var(--mx) var(--my),
-      rgba(0, 0, 0, .1) 12%, 
-      rgba(0, 0, 0, .15) 20%, 
-      rgba(0, 0, 0, .25) 120%
-    );
+	background-blend-mode: exclusion, hue, hard-light;
+	background-size: var(--imgsize), 200% 700%, 300%, 200%;
+	background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
 
-  background-blend-mode: exclusion, hue, hard-light;
-  background-size: var(--imgsize), 200% 700%, 300%, 200%;
-  background-position: center, 0% var(--posy), var(--posx) var(--posy), var(--posx) var(--posy);
-
-  filter: brightness(calc((var(--hyp)*0.4) + .5)) contrast(2.5) saturate(1);
-
+	filter: brightness(calc((var(--hyp) * 0.4) + 0.5)) contrast(2.5) saturate(1);
 }
 
-.card[data-rarity="rare holo v"][data-gallery="true"] .card__shine:after {
+.card[data-rarity='rare holo v'][data-gallery='true'] .card__shine:after {
+	content: '';
 
-  content: "";
+	background-size: var(--imgsize), 200% 400%, 195%, 200%;
+	background-position: center, 0% var(--posy), calc(var(--posx) * -1) calc(var(--posy) * -1),
+		var(--posx) var(--posy);
 
-  background-size: var(--imgsize), 200% 400%, 195%, 200%;
-  background-position: center, 0% var(--posy), calc( var(--posx) * -1) calc( var(--posy) * -1), var(--posx) var(--posy);
-
-  filter: brightness(calc((var(--hyp)*0.5) + .7)) contrast(2) saturate(1);
-  mix-blend-mode: exclusion;
-
+	filter: brightness(calc((var(--hyp) * 0.5) + 0.7)) contrast(2) saturate(1);
+	mix-blend-mode: exclusion;
 }
 
-
-.card[data-rarity="rare holo v"][data-gallery="true"][data-subtypes*="vmax"] .card__shine,
-.card[data-rarity="rare holo v"][data-gallery="true"][data-subtypes*="vmax"] .card__shine:after {
-
-    --img: url("https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/stylish.webp");
-    --imgsize: 48%;
-
+.card[data-rarity='rare holo v'][data-gallery='true'][data-subtypes*='vmax'] .card__shine,
+.card[data-rarity='rare holo v'][data-gallery='true'][data-subtypes*='vmax'] .card__shine:after {
+	--img: url('https://res.cloudinary.com/simey/image/upload/Dev/PokemonCards/stylish.webp');
+	--imgsize: 48%;
 }

--- a/static/cards.css
+++ b/static/cards.css
@@ -15,6 +15,12 @@
 
 }
 
+button[class^='card'] {
+	border: none;
+	background: transparent;
+	padding: 0;
+}
+
 
 
 /*


### PR DESCRIPTION
Due to everything in the cards being divs, being able to open the cards using basic keyboard navigation isn't possible. This pull request changes interactive components into buttons, adds aria-labels to each button so screen readers will read out which card they are over, and changes the event listener to be on click so it can be triggered with a keyboard "enter" press. It also (hopefully) removes the default styling from the buttons so it doesn't look any different.

To manually check this, firstly you should be able to click/mouseover like before. Secondly, you should be able to "tab" between each card and press "enter" to open/close them.

Note that I really don't know what I'm doing with Svelte, so if I've introduced any anti-patterns then I'm happy to change them. Also, I haven't checked this change in all browsers but it seems to work at least in Chrome and Firefox on macOS.