### PR TITLE
Change pointerup and keyup listeners on cards to click listener

### DIFF
--- a/src/lib/components/card.svelte
+++ b/src/lib/components/card.svelte
@@ -21,7 +21,7 @@
 
 	const back_loading = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACEAAAAuCAYAAACmsnC6AAAANklEQVR42u3OMQEAAAQAMKJJJT4ZXJ4twTKqJ56lhISEhISEhISEhISEhISEhISEhISEhMTdAodwTxGtMFP/AAAAAElFTkSuQmCC";
 	const front_loading = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACEAAAAuCAYAAACmsnC6AAAAN0lEQVR42u3OIQEAMAgAsNP/AkFfyIDCbAkWP6vfsZCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQ2BtyOnuhnmSZZAAAAABJRU5ErkJggg==";
-	
+
   let img_base = img.startsWith('http') ? '' : "https://images.pokemontcg.io/";
 	let front_img = "";
 
@@ -343,8 +343,7 @@
     <button
       class="card__rotator"
       bind:this={rotator}
-      on:pointerup={activate}
-      on:keyup={activate}
+      on:click={activate}
       on:pointermove={interact}
       on:mouseout={interactEnd}
       on:blur={deactivate}


### PR DESCRIPTION
On iOS, you can open a card but can't close it again. The exception to this is if you open another card - this closes the first card and opens the second, but then there's no way to close the second (without opening a third, etc).

Changing the `on:pointerup` and `on:keyup` listeners to `on:click` seems to resolve this (aka make it a standard button click listener). I don't know if there was a reason why these other listeners were chosen, hence making this a Draft PR for now, but if this change is okay then I'll open it up.