### PR TITLE
fix: shining card ✨ isn't rounded

### DIFF
--- a/src/lib/components/card-shine.svelte
+++ b/src/lib/components/card-shine.svelte
@@ -36,6 +36,7 @@
 .card__shine:after {
   grid-area: 1/1;
   transform: translateZ(1.2px);
+  border-radius: var(--radius);
 }
 
 


### PR DESCRIPTION
fix shining card isn't rounded (on safari)
- add border-radius on shining part
- tested on safari, chrome

Thanks for sharing @simeydotme